### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing authentication on cron settings endpoints

### DIFF
--- a/src/presentation/cronSettingsRoute.ts
+++ b/src/presentation/cronSettingsRoute.ts
@@ -2,6 +2,7 @@ import express from "express";
 import { logger } from "../utils/logger.js";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
+import { authMiddleware } from "../middleware/auth.js";
 
 const SETTINGS_PATH = process.env.CRON_SETTINGS_PATH || join(process.env.HOME || "/home/ubuntu", ".hermes", "cron-settings.json");
 
@@ -39,12 +40,12 @@ function saveSettings(s: CronSettings): void {
 
 export function mountCronSettingsRoutes(app: express.Application): void {
   // GET /api/settings/cron — read current schedule
-  app.get("/api/settings/cron", (_req, res) => {
+  app.get("/api/settings/cron", authMiddleware, (_req, res) => {
     res.json(loadSettings());
   });
 
   // PUT /api/settings/cron — update schedule; validates 5-field cron expression
-  app.put("/api/settings/cron", (req, res) => {
+  app.put("/api/settings/cron", authMiddleware, (req, res) => {
     const { dreams_schedule, dreams_enabled } = req.body as {
       dreams_schedule?: string;
       dreams_enabled?: boolean;


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix missing authentication on cron settings endpoints

🚨 Severity: HIGH
💡 Vulnerability: The `/api/settings/cron` endpoints for reading and updating the internal cron schedules were completely unauthenticated, allowing any user to read and modify internal configurations.
🎯 Impact: An attacker could modify the internal cron schedule for the application (and write to `cron-settings.json` on the disk).
🔧 Fix: Added `authMiddleware` to the `GET` and `PUT` `/api/settings/cron` endpoints.
✅ Verification: Ran `pnpm build` and `pnpm test` successfully. Verified the endpoints now require authentication.

---
*PR created automatically by Jules for task [7050642972832644304](https://jules.google.com/task/7050642972832644304) started by @giauphan*