### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons and switches in Control Center

### DIFF
--- a/dashboard/src/components/ControlCenterView.tsx
+++ b/dashboard/src/components/ControlCenterView.tsx
@@ -140,10 +140,10 @@ const freqLabels: Record<string, string> = {
                         </div>
                       </div>
                       <div style={{ display: 'flex', gap: '0.5rem' }}>
-                        <button onClick={() => copyToClipboard(key.key, key.id)} className="btn-ghost" style={{ padding: '0.5rem' }}>
+                        <button onClick={() => copyToClipboard(key.key, key.id)} className="btn-ghost" style={{ padding: '0.5rem' }} aria-label="Copy token" title="Copy token">
                           {copiedId === key.id ? <Check size={16} color="#00F0FF" /> : <Copy size={16} />}
                         </button>
-                        <button onClick={() => deleteKey(key.id)} className="btn-ghost" style={{ padding: '0.5rem', color: '#FF4B4B' }}>
+                        <button onClick={() => deleteKey(key.id)} className="btn-ghost" style={{ padding: '0.5rem', color: '#FF4B4B' }} aria-label="Delete token" title="Delete token">
                           <Trash2 size={16} />
                         </button>
                       </div>
@@ -188,6 +188,9 @@ const freqLabels: Record<string, string> = {
                 <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
                   <label style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>Enabled</label>
                   <button onClick={() => setCronEnabled(!cronEnabled)}
+                    role="switch"
+                    aria-checked={cronEnabled}
+                    aria-label="Enable dream sync"
                     style={{
                       width: '44px', height: '24px', borderRadius: '12px', border: 'none', cursor: 'pointer',
                       background: cronEnabled ? 'var(--primary-neon)' : 'rgba(255,255,255,0.2)',


### PR DESCRIPTION
### 💡 What
Added missing accessibility attributes to interactive elements in `ControlCenterView.tsx`:
- Added `aria-label` and `title` to the icon-only "Copy" and "Delete" buttons for access tokens.
- Added `role="switch"`, `aria-checked`, and `aria-label` to the custom "Enabled" switch for the cron schedule.

### 🎯 Why
Icon-only buttons are completely inaccessible to screen reader users without `aria-label` attributes, and mouse users benefit from tooltips (`title` attribute) explaining what the icons do. Furthermore, custom UI components like switches (often built with styled elements rather than native semantic HTML) must explicitly define their ARIA roles and states to be correctly interpreted by assistive technologies.

### 📸 Before/After
*(No visual changes aside from the addition of native browser tooltips on hover for the Copy and Delete buttons).*

### ♿ Accessibility
- Screen reader users can now understand the purpose of the Copy and Delete buttons.
- Mouse users get native browser tooltips explaining the buttons.
- Screen reader users can now understand that the "Enabled" button is a switch and can perceive its current on/off state.

---
*PR created automatically by Jules for task [10853236271087091762](https://jules.google.com/task/10853236271087091762) started by @giauphan*