### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing authentication on A2A endpoints

### DIFF
--- a/src/presentation/a2a/a2aRoutes.ts
+++ b/src/presentation/a2a/a2aRoutes.ts
@@ -12,6 +12,7 @@ import { A2AExecutor } from "./a2aExecutor.js";
 import type { JsonRpcRequest, JsonRpcResponse } from "../../types/a2a.js";
 import { randomUUID } from "node:crypto";
 import { logger } from "../../utils/logger.js";
+import { authMiddleware } from "../../middleware/auth.js";
 
 export function mountA2ARoutes(app: express.Express, executor: A2AExecutor, baseUrl: string): void {
   // === Agent Discovery ===
@@ -27,7 +28,7 @@ export function mountA2ARoutes(app: express.Express, executor: A2AExecutor, base
   });
 
   // === JSON-RPC 2.0 Endpoint ===
-  app.post("/a2a/jsonrpc", async (req, res) => {
+  app.post("/a2a/jsonrpc", authMiddleware, async (req, res) => {
     const body = req.body as JsonRpcRequest;
 
     // Validate JSON-RPC envelope
@@ -64,7 +65,7 @@ export function mountA2ARoutes(app: express.Express, executor: A2AExecutor, base
   });
 
   // === REST Convenience Endpoint ===
-  app.post("/a2a/rest/message", async (req, res) => {
+  app.post("/a2a/rest/message", authMiddleware, async (req, res) => {
     const { message, taskId } = req.body || {};
 
     if (!message || !message.parts) {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `/a2a/jsonrpc` and `/a2a/rest/message` endpoints in `src/presentation/a2a/a2aRoutes.ts` were missing authentication middleware (`authMiddleware`). Any client could trigger internal A2A operations (e.g. task scheduling, execution, or retrieving agent info) via these unauthenticated RPC routes.
🎯 **Impact:** An unauthorized user could potentially execute tasks on the agent, inject code into A2A executor, access private project metadata, or disrupt the agent system without providing a valid API key or Firebase token.
🔧 **Fix:** Imported `authMiddleware` and applied it to the sensitive RPC endpoints (`POST /a2a/jsonrpc` and `POST /a2a/rest/message`). 
✅ **Verification:** Verified that tests pass properly. The A2A jsonrpc now properly rejects unauthenticated attempts.

---
*PR created automatically by Jules for task [11455240254505027624](https://jules.google.com/task/11455240254505027624) started by @giauphan*