### PR TITLE
⚡ Bolt: [performance improvement] batch file discovery to prevent EMFILE limits while speeding up scans

### DIFF
--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -685,27 +685,39 @@ export async function discoverProjectsAsync(tenantId?: string): Promise<{ name: 
   }
 
   const seen = new Set<string>();
-  for (const dir of searchDirs) {
-    if (seen.has(dir)) continue;
+  const uniqueDirs = searchDirs.filter(dir => {
+    if (seen.has(dir) || isSystemIdeDirectory(dir)) return false;
     seen.add(dir);
-    if (isSystemIdeDirectory(dir)) continue;
+    return true;
+  });
 
-    if (await isProjectDirectoryAsync(dir)) {
-      try {
-        const analysisPath = path.join(dir, ".codeatlas", "analysis.json");
-        let modifiedAt: Date;
-        if (await fileExists(analysisPath)) {
-          modifiedAt = (await fs.promises.stat(analysisPath)).mtime;
-        } else {
-          modifiedAt = (await fs.promises.stat(dir)).mtime;
+  const chunkSize = 50; // Batch file system operations to prevent EMFILE
+  for (let i = 0; i < uniqueDirs.length; i += chunkSize) {
+    const chunk = uniqueDirs.slice(i, i + chunkSize);
+    const results = await Promise.all(
+      chunk.map(async (dir) => {
+        if (await isProjectDirectoryAsync(dir)) {
+          try {
+            const analysisPath = path.join(dir, ".codeatlas", "analysis.json");
+            let modifiedAt: Date;
+            if (await fileExists(analysisPath)) {
+              modifiedAt = (await fs.promises.stat(analysisPath)).mtime;
+            } else {
+              modifiedAt = (await fs.promises.stat(dir)).mtime;
+            }
+            return {
+              name: path.basename(dir),
+              dir,
+              analysisPath,
+              modifiedAt,
+            };
+          } catch { /* skip */ }
         }
-        projects.push({
-          name: path.basename(dir),
-          dir,
-          analysisPath,
-          modifiedAt,
-        });
-      } catch { /* skip */ }
+        return null;
+      })
+    );
+    for (const res of results) {
+      if (res) projects.push(res);
     }
   }
 


### PR DESCRIPTION
💡 What: Replaced sequential iteration with chunked asynchronous operations (`Promise.all` in batches of 50) for checking `isProjectDirectoryAsync` and fetching stats on multiple subdirectories simultaneously in `discoverProjectsAsync`.
🎯 Why: Iterating directories one by one is slow when exploring deep file systems. Unbounded parallel execution hits EMFILE limits. Chunking provides the optimal balance of concurrency vs stability.
📊 Impact: Expected to greatly reduce scan time for heavily nested workspaces with multiple `.codeatlas` projects, especially over network mounts or slower SSDs, while remaining safe.
🔬 Measurement: Verify overall request time for indexing/discovering large workspaces.

---
*PR created automatically by Jules for task [10833061337635098639](https://jules.google.com/task/10833061337635098639) started by @giauphan*