### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and roles to interactive elements in Control Center

### DIFF
--- a/dashboard/src/components/ControlCenterView.tsx
+++ b/dashboard/src/components/ControlCenterView.tsx
@@ -140,10 +140,10 @@ const freqLabels: Record<string, string> = {
                         </div>
                       </div>
                       <div style={{ display: 'flex', gap: '0.5rem' }}>
-                        <button onClick={() => copyToClipboard(key.key, key.id)} className="btn-ghost" style={{ padding: '0.5rem' }}>
+                        <button aria-label="Copy token" title="Copy token" onClick={() => copyToClipboard(key.key, key.id)} className="btn-ghost" style={{ padding: '0.5rem' }}>
                           {copiedId === key.id ? <Check size={16} color="#00F0FF" /> : <Copy size={16} />}
                         </button>
-                        <button onClick={() => deleteKey(key.id)} className="btn-ghost" style={{ padding: '0.5rem', color: '#FF4B4B' }}>
+                        <button aria-label="Delete token" title="Delete token" onClick={() => deleteKey(key.id)} className="btn-ghost" style={{ padding: '0.5rem', color: '#FF4B4B' }}>
                           <Trash2 size={16} />
                         </button>
                       </div>
@@ -186,8 +186,8 @@ const freqLabels: Record<string, string> = {
                 </div>
 
                 <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-                  <label style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>Enabled</label>
-                  <button onClick={() => setCronEnabled(!cronEnabled)}
+                  <label id="cron-enabled-label" style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>Enabled</label>
+                  <button role="switch" aria-checked={cronEnabled} aria-labelledby="cron-enabled-label" onClick={() => setCronEnabled(!cronEnabled)}
                     style={{
                       width: '44px', height: '24px', borderRadius: '12px', border: 'none', cursor: 'pointer',
                       background: cronEnabled ? 'var(--primary-neon)' : 'rgba(255,255,255,0.2)',


### PR DESCRIPTION
💡 What: Added standard ARIA attributes (`aria-label`, `title`, `role`, `aria-checked`, `aria-labelledby`) to interactive elements in the `ControlCenterView.tsx` component.
🎯 Why: To make the Control Center fully accessible to screen readers, allowing users to understand the purpose of icon-only buttons and the state of the custom toggle switch without visual cues.
📸 Before/After: Visuals remain unchanged, but the DOM now includes proper semantic structure for accessibility.
♿ Accessibility: Improved screen reader experience by adding descriptive labels for token actions and transforming a generic button into a recognizable switch toggle.

---
*PR created automatically by Jules for task [559725757085039541](https://jules.google.com/task/559725757085039541) started by @giauphan*