### PR TITLE
⚡ Bolt: [performance improvement] Fix N+1 queries in consolidation engine deduplication

### DIFF
--- a/src/services/consolidationEngine.ts
+++ b/src/services/consolidationEngine.ts
@@ -139,14 +139,15 @@ export class ConsolidationEngine {
         }
 
         // Batch delete duplicate concepts using executeMany for N+1 avoidance.
-        for (const id of toRemove) {
+        if (toRemove.length > 0) {
           try {
-            await connection.execute(
+            const binds = toRemove.map((id) => ({ id }));
+            await connection.executeMany(
               `DELETE FROM ai_dreaming_memory WHERE id = :id`,
-              { id } as any,
+              binds as any,
               { autoCommit: true }
             );
-            merged++;
+            merged += toRemove.length;
           } catch {
             // skip delete errors
           }


### PR DESCRIPTION
**💡 What**
Replaced a `for` loop executing sequential `connection.execute` deletion queries with a single batched `connection.executeMany` operation in `src/services/consolidationEngine.ts`.

**🎯 Why**
The previous implementation had a comment intending to avoid N+1 queries by using `executeMany`, but the actual implementation incorrectly ran single `DELETE` queries iteratively inside a loop. This created a severe database bottleneck when deduplicating a large number of dreams.

**📊 Impact**
Reduces database round-trips from N (where N is the number of dreams to delete) to 1. This massively speeds up the consolidation engine's performance when processing large batches of duplicate concepts.

**🔬 Measurement**
Run a large consolidation job and monitor network traffic or database query logs. The total time spent in the `dedupDreams` phase should drop significantly as the batch size increases. Tests run via `pnpm test` confirm no functional regressions.

---
*PR created automatically by Jules for task [895302910491298487](https://jules.google.com/task/895302910491298487) started by @giauphan*