### PR TITLE
fix(db): add missing else block to dreaming memory vector migration

### DIFF
--- a/scripts/db-init.ts
+++ b/scripts/db-init.ts
@@ -220,6 +220,8 @@ async function run() {
             );
           }
           console.log("   └─ ✅ Dreaming vector fixed to VECTOR(4096, FLOAT32)");
+        } else {
+          console.log("   ✅ Dreaming vector dimension already 4096.");
         }
       }
     } catch (err: any) {


### PR DESCRIPTION
Added the missing `else` block to the vector dimension check for `ai_dreaming_memory` in `scripts/db-init.ts`. It now logs a success message if the dimension is already 4096, which is consistent with the `ai_semantic_memory` block above it.

---
*PR created automatically by Jules for task [3382014020715565829](https://jules.google.com/task/3382014020715565829) started by @giauphan*