### PR TITLE
Fix logger crash on circular meta objects

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -69,7 +69,13 @@ function log(level: Level, ...args: unknown[]): void {
       msg: message,
     };
     if (meta) entry.meta = meta;
-    const output = JSON.stringify(entry);
+    let output: string;
+    try {
+      output = JSON.stringify(entry);
+    } catch {
+      entry.meta = String(meta);
+      output = JSON.stringify(entry);
+    }
     if (level === "error" || level === "warn") {
       process.stderr.write(output + "\n");
     } else {
@@ -79,7 +85,11 @@ function log(level: Level, ...args: unknown[]): void {
     const prefix = `[${ts}] [${level.toUpperCase()}]`;
     let output = `${prefix} ${message}`;
     if (meta) {
-      output += ` ${JSON.stringify(meta)}`;
+      try {
+        output += ` ${JSON.stringify(meta)}`;
+      } catch {
+        output += ` ${String(meta)}`;
+      }
     }
     if (level === "error") {
       process.stderr.write(output + "\n");

--- a/tests/unit/utils/logger.test.ts
+++ b/tests/unit/utils/logger.test.ts
@@ -229,6 +229,30 @@ describe('Logger', () => {
     // It does not try/catch here! It only try/catches inside `stringify(val)`.
     // Wait... if I pass circularObj as the *last* arg, it becomes `meta`.
     // And JSON.stringify(meta) WILL throw.
-    // Let's modify logger.ts slightly to fix that bug while adding tests.
+    logger.info('circular as meta', circularObj);
+    assert.strictEqual(stdoutSpy.mock.callCount(), 2);
+    const output2 = stdoutSpy.mock.calls[1].arguments[0];
+    assert.ok(output2.includes('circular as meta [object Object]'));
+  });
+
+  test('should fallback to String() for circular objects in JSON mode', async () => {
+    process.env.LOG_LEVEL = 'debug';
+    process.env.LOG_FORMAT = 'json';
+    const logger = await getLogger();
+    stdoutSpy.mock.resetCalls();
+    stderrSpy.mock.resetCalls();
+
+    const circularObj: any = {};
+    circularObj.self = circularObj;
+
+    logger.info('circular as meta in JSON', circularObj);
+
+    assert.strictEqual(stdoutSpy.mock.callCount(), 1);
+    const output = stdoutSpy.mock.calls[0].arguments[0];
+    const parsed = JSON.parse(output);
+
+    assert.strictEqual(parsed.level, 'info');
+    assert.strictEqual(parsed.msg, 'circular as meta in JSON');
+    assert.strictEqual(parsed.meta, '[object Object]');
   });
 });


### PR DESCRIPTION
**Fix logger failure with circular objects as metadata**

When providing circular objects as the final argument (treated as `meta`), the logger would crash unhandled inside `log()` where it builds the final output via `JSON.stringify(meta)` or `JSON.stringify(entry)`.

*  Wrapped `JSON.stringify` logic inside `try/catch` in both "json" and "pretty" formatting paths.
*  If serialization fails, uses `String(meta)` as a fallback (which is standard behavior matching our standalone `stringify` behavior in that same file).
*  Implemented missing test cases to prove circular objects no longer crash `logger.info()` directly in both `pretty` and `json` formats.

---
*PR created automatically by Jules for task [2351393073858741151](https://jules.google.com/task/2351393073858741151) started by @giauphan*