### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal vulnerability in project name resolution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Path Traversal in Project Name Resolution
+**Vulnerability:** Path traversal risk allowing projects to potentially escape tenant isolation directories.
+**Learning:** `path.basename()` correctly strips path components but returns `.` for `.` and `..` for `..`. When combined with `path.join()`, this can allow traversal out of a restricted directory if the input is malicious.
+**Prevention:** Always validate that the output of `path.basename()` is not `.` or `..`, and ensure that inputs intended to be strings are indeed strings before processing them.

--- a/src/presentation/httpServer.ts
+++ b/src/presentation/httpServer.ts
@@ -383,6 +383,9 @@ app.get("/api/projects/memory", authMiddleware, async (req, res) => {
     }
 
     const cleanProjectName = path.basename(projectName.trim());
+    if (!cleanProjectName || cleanProjectName === "." || cleanProjectName === "..") {
+      return res.status(400).json({ error: "Invalid project name" });
+    }
 
     if (!process.env.ORACLE_CONN_STRING) {
       return res.json({
@@ -608,15 +611,19 @@ app.post("/api/projects/sync", authMiddleware, localRateLimiter, async (req, res
     }
     
     const { projectName, analysis, businessRule, changeDescription } = req.body;
-    if (!projectName || !analysis) {
+    if (!projectName || typeof projectName !== "string" || !analysis) {
       return res.status(400).json({ error: "Missing projectName or analysis data" });
+    }
+
+    // Clean project name to avoid directory traversal
+    const cleanProjectName = path.basename(projectName);
+    if (!cleanProjectName || cleanProjectName === "." || cleanProjectName === "..") {
+      return res.status(400).json({ error: "Invalid project name" });
     }
 
     // Queue the heavy file write & database sync operations to prevent connection pool starvation/conflicts
     const result = await syncQueue.enqueue(async () => {
       const executeTask = async () => {
-        // Clean project name to avoid directory traversal
-        const cleanProjectName = path.basename(projectName);
         
         // Resolve project directory on the VPS
         let projectDir: string;


### PR DESCRIPTION
Severity: HIGH

Vulnerability:
The application used `path.basename()` to clean `projectName` inputs. However, `path.basename('.')` returns `.` and `path.basename('..')` returns `..`. When passed into `path.join()`, this allows an attacker to perform a path traversal attack to escape the intended directory, which is especially critical in multi-tenant environments where a user could potentially access or overwrite files in another tenant's project directory or the system root.

Impact:
An authenticated user could send malicious payloads (e.g., `projectName = '..'`) to bypass directory isolation, potentially leading to unauthorized data access, file overwrites, and telemetry manipulation across isolated tenant boundaries.

Fix:
Explicitly checked that the result of `path.basename()` is not `.` or `..` and ensured the input type is strictly a string. Returned HTTP 400 Bad Request when an invalid project name is detected.

Verification:
- Added manual checks for `.` and `..`.
- Successfully ran the test suite (`pnpm test`) with no regressions.
- Successfully built the code (`pnpm run build`).

---
*PR created automatically by Jules for task [8496594348279560980](https://jules.google.com/task/8496594348279560980) started by @giauphan*