### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix SQL Injection in GenomeService

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-14 - SQL Injection Risk in GenomeService
+**Vulnerability:** A SQL Injection risk was found in `src/services/genomeService.ts` where arrays were joined directly into SQL update query strings without sanitization.
+**Learning:** Using dynamic arrays to construct SQL queries is prone to SQL Injection if not carefully validated.
+**Prevention:** Explicitly filter update strings against a strict allowlist.

--- a/patch_genome.py
+++ b/patch_genome.py
@@ -1,0 +1,33 @@
+import re
+
+with open('src/services/genomeService.ts', 'r') as f:
+    content = f.read()
+
+# Fix mutateGene
+def replace_mutate(match):
+    return """const safeUpdates = updates.filter(u => ALLOWED_MUTATE_UPDATES.has(u));
+      if (safeUpdates.length === 0) return geneId; // Return since the return type is Promise<string>
+"""
+
+content = re.sub(
+    r'const safeUpdates = updates\.filter\(u => ALLOWED_MUTATE_UPDATES\.has\(u\)\);',
+    replace_mutate,
+    content,
+    count=1
+)
+
+# Fix updateGene
+def replace_update(match):
+    return """const safeSets = sets.filter(s => ALLOWED_UPDATE_SETS.has(s));
+      if (safeSets.length === 0) return;"""
+
+content = re.sub(
+    r'const safeSets = sets\.filter\(s => ALLOWED_UPDATE_SETS\.has\(s\)\);',
+    replace_update,
+    content,
+    count=1
+)
+
+
+with open('src/services/genomeService.ts', 'w') as f:
+    f.write(content)

--- a/src/services/genomeService.ts
+++ b/src/services/genomeService.ts
@@ -570,8 +570,20 @@ export class GenomeService {
       binds.conf = newConfidence;
       binds.sr = newSuccessRate;
 
+
+      const ALLOWED_MUTATE_UPDATES = new Set([
+        "description = :desc",
+        "solution = :sol",
+        "confidence = :conf",
+        "version = version + 1",
+        "success_rate = :sr",
+        "evolution_score = evolution_score + 1",
+        "updated_at = CURRENT_TIMESTAMP"
+      ]);
+      const safeUpdates = updates.filter(u => ALLOWED_MUTATE_UPDATES.has(u));
+
       await connection.execute(
-        `UPDATE codeatlas_genome SET ${updates.join(", ")} WHERE id = :id`,
+        `UPDATE codeatlas_genome SET ${safeUpdates.join(", ")} WHERE id = :id`,
         binds as any,
         { autoCommit: true }
       );
@@ -1067,8 +1079,26 @@ Apply this knowledge when encountering similar problems.
         }
       }
 
-      if (sets.length === 1) return; // nothing to update
-      const sql = `UPDATE codeatlas_genome SET ${sets.join(", ")} WHERE id = :id`;
+
+      const ALLOWED_UPDATE_SETS = new Set([
+        "name = :name",
+        "description = :desc",
+        "problem = :problem",
+        "solution = :solution",
+        "architecture = :arch",
+        "category = :cat",
+        "dependencies = :deps",
+        "confidence = :conf",
+        "version = :ver",
+        "updated_at = CURRENT_TIMESTAMP",
+        "embedding = :emb"
+      ]);
+      const safeSets = sets.filter(s => ALLOWED_UPDATE_SETS.has(s));
+
+      if (safeSets.length === 1 && safeSets[0] === "updated_at = CURRENT_TIMESTAMP") return; // nothing to update
+
+      const sql = `UPDATE codeatlas_genome SET ${safeSets.join(", ")} WHERE id = :id`;
+
       await connection.execute(sql, binds as any, { autoCommit: true });
     } catch (err) {
       logger.error(`updateGene failed for ${geneId}`, err);

--- a/src/services/genomeService.ts
+++ b/src/services/genomeService.ts
@@ -581,6 +581,8 @@ export class GenomeService {
         "updated_at = CURRENT_TIMESTAMP"
       ]);
       const safeUpdates = updates.filter(u => ALLOWED_MUTATE_UPDATES.has(u));
+      if (safeUpdates.length === 0) return geneId; // Return since the return type is Promise<string>
+
 
       await connection.execute(
         `UPDATE codeatlas_genome SET ${safeUpdates.join(", ")} WHERE id = :id`,
@@ -1094,6 +1096,7 @@ Apply this knowledge when encountering similar problems.
         "embedding = :emb"
       ]);
       const safeSets = sets.filter(s => ALLOWED_UPDATE_SETS.has(s));
+      if (safeSets.length === 0) return;
 
       if (safeSets.length === 1 && safeSets[0] === "updated_at = CURRENT_TIMESTAMP") return; // nothing to update
 


### PR DESCRIPTION
## Severity
CRITICAL/HIGH

## Vulnerability
SQL Injection risk with string formatting in `src/services/genomeService.ts`. The arrays `updates` and `sets` were joined directly into SQL update queries without any prior validation or sanitization.

## Impact
If the keys for updates are derived from unsanitized input, an attacker could craft malicious input to execute arbitrary SQL commands, potentially exposing or modifying the entire knowledge base data.

## Fix
Introduced strict set-based allowlists to explicitly filter the update components before joining them into the SQL string. This ensures only intended column updates are passed to the SQL command.

## Verification
- Added explicit allowlists `ALLOWED_MUTATE_UPDATES` and `ALLOWED_UPDATE_SETS`.
- Passed the full test suite (`pnpm test`).
- Passed the build process (`pnpm run build`).

---
*PR created automatically by Jules for task [3963366522280512816](https://jules.google.com/task/3963366522280512816) started by @giauphan*