### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix timing attack vulnerability in superadmin API key comparison

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-14 - Fix timing attack vulnerability in superadmin API key comparison
+**Vulnerability:** Hardcoded bypass based on string comparison of keys (`apiKey === superAdminKey`) which is vulnerable to timing attacks.
+**Learning:** String comparison operators (`===`, `==`) leak information about how many characters match before a mismatch occurs by exiting early.
+**Prevention:** Always use constant-time comparison functions like `crypto.timingSafeEqual` for comparing secrets like passwords, tokens, or API keys. Ensure length checks are handled securely.

--- a/src/repositories.ts
+++ b/src/repositories.ts
@@ -147,8 +147,12 @@ export class AuthenticateUserUseCase {
     }
 
     // 1. Super Admin Bypass
-    if (superAdminKey && apiKey === superAdminKey) {
-      return { tier: 'enterprise', uid: 'admin', keyId: 'admin', expires: Infinity };
+    if (superAdminKey) {
+      const apiKeyBuffer = Buffer.from(apiKey);
+      const adminKeyBuffer = Buffer.from(superAdminKey);
+      if (apiKeyBuffer.length === adminKeyBuffer.length && crypto.timingSafeEqual(apiKeyBuffer, adminKeyBuffer)) {
+        return { tier: 'enterprise', uid: 'admin', keyId: 'admin', expires: Infinity };
+      }
     }
 
     // 2. Check Local RAM Cache


### PR DESCRIPTION
### 🎯 What
Fixed a timing attack vulnerability in `AuthenticateUserUseCase.execute()` where the `superAdminKey` was being compared to the provided `apiKey` using a standard string comparison operator (`===`).

### ⚠️ Risk
Standard string comparison operators (`===`) exit early as soon as a character mismatch is found. This leaks information about the length of the matching prefix because the comparison takes slightly longer for strings that share a longer common prefix. An attacker could potentially exploit this timing difference to perform a timing attack and incrementally guess the `superAdminKey` character by character, leading to a full authentication bypass and unauthorized administrative access.

### 🛡️ Solution
Replaced the insecure string comparison with a constant-time comparison using Node.js's built-in `crypto.timingSafeEqual` function. This function takes exactly the same amount of time to execute regardless of how many characters match, thus preventing timing side-channel attacks. We first verify that both strings are of equal length (after converting them to `Buffer` objects, as `timingSafeEqual` requires `Buffer`s of equal length) before performing the safe comparison.

### ✅ Verification
- Test suite passing (`pnpm test`).
- Typechecking passing (`pnpm build`).
- `sentinel.md` learning documented for future reference.

---
*PR created automatically by Jules for task [5003253643550597105](https://jules.google.com/task/5003253643550597105) started by @giauphan*