### PR TITLE
🎨 Palette: [Accessibility] Fix keyboard navigation for memory filter tags

### DIFF
--- a/dashboard/src/components/DreamMemoryView.tsx
+++ b/dashboard/src/components/DreamMemoryView.tsx
@@ -136,15 +136,22 @@ export function DreamMemoryView() {
 
       <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1.5rem', flexWrap: 'wrap' }}>
         {['KNOWLEDGE', 'PREFERENCE', 'MISTAKE', 'PATTERN'].map(type => (
-          <div key={type} onClick={() => toggleType(type)}
+          <button
+            key={type}
+            type="button"
+            onClick={() => toggleType(type)}
+            aria-pressed={selectedTypes.includes(type)}
             style={{
               padding: '0.4rem 1rem', borderRadius: '100px', cursor: 'pointer', fontSize: '0.8rem', fontWeight: 700,
               background: selectedTypes.includes(type) ? `${typeColors[type]}22` : 'rgba(255,255,255,0.05)',
               border: `1px solid ${selectedTypes.includes(type) ? typeColors[type] : 'rgba(255,255,255,0.1)'}`,
-              color: selectedTypes.includes(type) ? typeColors[type] : 'var(--text-muted)'
-            }}>
+              color: selectedTypes.includes(type) ? typeColors[type] : 'var(--text-muted)',
+              outline: 'none'
+            }}
+            className="focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-50"
+          >
             {type}
-          </div>
+          </button>
         ))}
       </div>
 


### PR DESCRIPTION
💡 **What:** Converted the memory filter tags ('KNOWLEDGE', 'PREFERENCE', 'MISTAKE', 'PATTERN') in `DreamMemoryView` from `<div>` to semantic `<button>` elements.
🎯 **Why:** The previous `div` implementation meant these interactive filters could not be reached via keyboard navigation (Tab key) and screen readers did not announce them as interactive or reflect their toggle state.
♿ **Accessibility:**
- Changed tags to `<button type="button">` to allow keyboard focus and interaction.
- Added `aria-pressed` attribute to clearly communicate the active toggle state to screen readers.
- Added visible focus styling (`focus-visible:ring-2`) for keyboard users.

---
*PR created automatically by Jules for task [13206713940882896968](https://jules.google.com/task/13206713940882896968) started by @giauphan*