### PR TITLE
⚡ Bolt: [performance improvement] Batch genome service DB updates

### DIFF
--- a/src/services/genomeService.ts
+++ b/src/services/genomeService.ts
@@ -222,12 +222,14 @@ export class GenomeService {
       }));
 
       // Increment usage count for returned genes
-      for (const g of genes) {
+      // ⚡ Bolt Optimization: Replaced N+1 loop with a single executeMany batch update to reduce DB roundtrips.
+      if (genes.length > 0) {
         try {
-          await connection.execute(
+          const binds = genes.map(g => ({ id: g.id }));
+          await connection.executeMany(
             `UPDATE codeatlas_genome SET usage_count = usage_count + 1,
              updated_at = CURRENT_TIMESTAMP WHERE id = :id`,
-            { id: g.id } as any,
+            binds as any,
             { autoCommit: true }
           );
         } catch { /* skip */ }
@@ -407,18 +409,25 @@ export class GenomeService {
       });
 
       // Mark source genes as merged
-      for (const g of genes) {
-        const gid = String(g[0]);
-        await connection.execute(
+      // ⚡ Bolt Optimization: Batch updates and inserts instead of querying inside loop (avoids N+1 DB roundtrips)
+      if (genes.length > 0) {
+        const updateBinds = genes.map(g => ({ id: String(g[0]) }));
+        await connection.executeMany(
           `UPDATE codeatlas_genome SET status = 'merged', updated_at = CURRENT_TIMESTAMP WHERE id = :id`,
-          { id: gid } as any,
+          updateBinds as any,
           { autoCommit: true }
         );
+
         // Record relationship
-        await connection.execute(
+        const insertBinds = genes.map(g => ({
+          id: `rel-${randomUUID().slice(0, 8)}`,
+          src: String(g[0]),
+          tgt: geneId
+        }));
+        await connection.executeMany(
           `INSERT INTO gene_relationships (id, source_id, target_id, relationship, weight)
            VALUES (:id, :src, :tgt, 'merged_into', 1.0)`,
-          { id: `rel-${randomUUID().slice(0, 8)}`, src: gid, tgt: geneId } as any,
+          insertBinds as any,
           { autoCommit: true }
         );
       }
@@ -592,14 +601,16 @@ export class GenomeService {
       await setSessionContext(connection);
 
       let count = 0;
-      for (const id of geneIds) {
-        const result = await connection.execute(
+      // ⚡ Bolt Optimization: Batch retirement update using executeMany instead of executing queries in a loop.
+      if (geneIds.length > 0) {
+        const binds = geneIds.map(id => ({ id }));
+        const result = await connection.executeMany(
           `UPDATE codeatlas_genome SET status = 'retired', updated_at = CURRENT_TIMESTAMP
            WHERE id = :id AND status != 'retired'`,
-          { id } as any,
+          binds as any,
           { autoCommit: true }
         );
-        count += result.rowsAffected || 0;
+        count = result.rowsAffected || 0;
       }
 
       logger.info(`[Genome] Retired ${count} genes`);

--- a/tests/unit/genome-service.test.ts
+++ b/tests/unit/genome-service.test.ts
@@ -16,6 +16,7 @@ const srcDir = path.resolve(import.meta.dirname, '../../src');
 
 const mockConnection = {
   execute: mock.fn(),
+  executeMany: mock.fn(),
   close: mock.fn(),
 };
 
@@ -163,7 +164,7 @@ describe('GenomeService', () => {
       await GenomeService.searchGenes('test', { limit: 5 });
 
       // Should have at least one UPDATE usage_count call
-      const updateCalls = mockConnection.execute.mock.calls.filter(
+      const updateCalls = mockConnection.executeMany.mock.calls.filter(
         (c: any) => typeof c.arguments[0] === 'string' && c.arguments[0].includes('usage_count = usage_count + 1')
       );
       assert.ok(updateCalls.length > 0);
@@ -173,9 +174,11 @@ describe('GenomeService', () => {
   // ── mergeGenes ─────────────────────────────────────────────────────
   describe('mergeGenes()', () => {
     test('combines 2 genes into one and marks sources as merged', async () => {
-      mockConnection.execute.mock.mockImplementation(async (sql: string) => {
+      mockConnection.executeMany.mock.mockImplementation(async (sql: string) => {
         if (sql.includes('UPDATE codeatlas_genome SET status')) return { rowsAffected: 1 };
         if (sql.includes('INSERT INTO gene_relationships')) return { rowsAffected: 1 };
+      });
+      mockConnection.execute.mock.mockImplementation(async (sql: string) => {
         if (sql.includes('SELECT id, version FROM codeatlas_genome')) return { rows: [] };
         return { rows: [mockGeneRow('gene-1', 'Source A'), mockGeneRow('gene-2', 'Source B')] };
       });
@@ -263,7 +266,7 @@ describe('GenomeService', () => {
   // ── retireGenes ────────────────────────────────────────────────────
   describe('retireGenes()', () => {
     test('retires genes and returns count', async () => {
-      mockConnection.execute.mock.mockImplementation(async () => ({ rowsAffected: 1 }));
+      mockConnection.executeMany.mock.mockImplementation(async () => ({ rowsAffected: 2 }));
 
       const count = await GenomeService.retireGenes(['gene-1', 'gene-2']);
       assert.equal(count, 2);


### PR DESCRIPTION
💡 What: Replaced several instances of `connection.execute` inside loops with batched `connection.executeMany` calls in `GenomeService`. Also updated `mockConnection` in unit tests to track `executeMany` calls.
🎯 Why: Executing queries inside a loop is a classic N+1 performance bottleneck that adds significant database roundtrips.
📊 Impact: Reduces database latency and overall load by substituting N separate query roundtrips with a single network call.
🔬 Measurement: Verify behavior via `pnpm test` and examine the modified `src/services/genomeService.ts` to ensure batch operations are correctly applied.

---
*PR created automatically by Jules for task [1705253461587544295](https://jules.google.com/task/1705253461587544295) started by @giauphan*