### PR TITLE
⚡ Bolt: [performance improvement] Batch update access_count in concept search

### DIFF
--- a/src/presentation/consolidationRoutes.ts
+++ b/src/presentation/consolidationRoutes.ts
@@ -76,14 +76,14 @@ export function mountConsolidationRoutes(app: express.Application): void {
 
         res.json({ concepts });
 
-        // ⚡ Bolt Optimization: Batch access_count update using executeMany to avoid N+1 DB roundtrips.
+        // Batch update access counts - reduces N roundtrips to 1
         if (concepts.length > 0) {
           try {
             const binds = concepts.map(c => ({ id: c.id }));
             await connection.executeMany(
               `UPDATE codeatlas_concepts SET access_count = access_count + 1, last_accessed_at = CURRENT_TIMESTAMP WHERE id = :id`,
-              binds as any,
-              { autoCommit: true }
+              binds,
+              { autoCommit: true, batchErrors: true }
             );
           } catch { /* skip */ }
         }

--- a/src/presentation/consolidationRoutes.ts
+++ b/src/presentation/consolidationRoutes.ts
@@ -76,12 +76,13 @@ export function mountConsolidationRoutes(app: express.Application): void {
 
         res.json({ concepts });
 
-        // Track access count for retrieved concepts
-        for (const c of concepts) {
+        // ⚡ Bolt Optimization: Batch access_count update using executeMany to avoid N+1 DB roundtrips.
+        if (concepts.length > 0) {
           try {
-            await connection.execute(
+            const binds = concepts.map(c => ({ id: c.id }));
+            await connection.executeMany(
               `UPDATE codeatlas_concepts SET access_count = access_count + 1, last_accessed_at = CURRENT_TIMESTAMP WHERE id = :id`,
-              { id: c.id } as any,
+              binds as any,
               { autoCommit: true }
             );
           } catch { /* skip */ }


### PR DESCRIPTION
💡 What: Replaced the `for` loop that iterates over `concepts` and executes an `UPDATE` query for each concept to increment the `access_count` in `src/presentation/consolidationRoutes.ts` with a single `connection.executeMany`.

🎯 Why: The previous implementation resulted in an N+1 query problem, making a roundtrip to the Oracle database for every concept returned in the search results. This adds significant latency to the endpoint, especially as the number of returned concepts grows. Batching these into a single database operation significantly reduces the overhead.

📊 Impact: Expected to reduce endpoint latency by eliminating N-1 database roundtrips.

🔬 Measurement: Verify by executing the `GET /api/concepts/search` endpoint and observing lower latency for a response with multiple returned concepts. Ensure that the access count for returned concepts increments correctly in the database.

---
*PR created automatically by Jules for task [17243013973765717901](https://jules.google.com/task/17243013973765717901) started by @giauphan*