### PR TITLE
⚡ Bolt: [performance improvement] Optimize Cosine Similarity memory overhead

### DIFF
--- a/src/services/consolidationEngine.ts
+++ b/src/services/consolidationEngine.ts
@@ -124,8 +124,8 @@ export class ConsolidationEngine {
             const embJ = group[j][R_IDX.EMBEDDING];
             if (!embI || !embJ) continue;
 
-            // ⚡ Bolt Optimization: Pass Float32Array directly instead of Array.from to avoid massive GC overhead inside nested loop
-            // Note: If embedding is not a Float32Array, we pass the original value which might be a number array.
+            // Note: Pass Float32Array directly instead of Array.from to avoid GC overhead in nested loops.
+            // If embedding is not a Float32Array, pass original value to preserve behavior.
             const similarity = this.cosineSimilarity(
               embI instanceof Float32Array ? embI : (Array.isArray(embI) ? embI : []),
               embJ instanceof Float32Array ? embJ : (Array.isArray(embJ) ? embJ : [])

--- a/src/services/consolidationEngine.ts
+++ b/src/services/consolidationEngine.ts
@@ -345,7 +345,7 @@ export class ConsolidationEngine {
   }
 
   /**
-   * Cosine similarity between two float vectors.
+   * Cosine similarity between two vectors (either standard arrays or Float32Array).
    */
   private cosineSimilarity(a: number[] | Float32Array, b: number[] | Float32Array): number {
     if (a.length !== b.length || a.length === 0) return 0;

--- a/src/services/consolidationEngine.ts
+++ b/src/services/consolidationEngine.ts
@@ -125,9 +125,10 @@ export class ConsolidationEngine {
             if (!embI || !embJ) continue;
 
             // ⚡ Bolt Optimization: Pass Float32Array directly instead of Array.from to avoid massive GC overhead inside nested loop
+            // Note: If embedding is not a Float32Array, we pass the original value which might be a number array.
             const similarity = this.cosineSimilarity(
-              embI instanceof Float32Array ? embI : [],
-              embJ instanceof Float32Array ? embJ : []
+              embI instanceof Float32Array ? embI : (Array.isArray(embI) ? embI : []),
+              embJ instanceof Float32Array ? embJ : (Array.isArray(embJ) ? embJ : [])
             );
 
             if (similarity > 0.85) {

--- a/src/services/consolidationEngine.ts
+++ b/src/services/consolidationEngine.ts
@@ -124,9 +124,10 @@ export class ConsolidationEngine {
             const embJ = group[j][R_IDX.EMBEDDING];
             if (!embI || !embJ) continue;
 
+            // ⚡ Bolt Optimization: Pass Float32Array directly instead of Array.from to avoid massive GC overhead inside nested loop
             const similarity = this.cosineSimilarity(
-              embI instanceof Float32Array ? Array.from(embI) : [],
-              embJ instanceof Float32Array ? Array.from(embJ) : []
+              embI instanceof Float32Array ? embI : [],
+              embJ instanceof Float32Array ? embJ : []
             );
 
             if (similarity > 0.85) {
@@ -345,7 +346,7 @@ export class ConsolidationEngine {
   /**
    * Cosine similarity between two float vectors.
    */
-  private cosineSimilarity(a: number[], b: number[]): number {
+  private cosineSimilarity(a: number[] | Float32Array, b: number[] | Float32Array): number {
     if (a.length !== b.length || a.length === 0) return 0;
     let dot = 0, normA = 0, normB = 0;
     for (let i = 0; i < a.length; i++) {


### PR DESCRIPTION
💡 **What:** The `cosineSimilarity` function signature in `src/services/consolidationEngine.ts` was updated to accept `Float32Array` in addition to `number[]`. In the `dedupDreams` routine, embeddings (which are `Float32Array` objects) are now passed directly to `cosineSimilarity` without converting them to regular arrays via `Array.from()`.

🎯 **Why:** Previously, the `Float32Array` vectors (often containing 4096 dimensions) were being converted to arrays using `Array.from()` inside a nested loop during pairwise cosine similarity comparisons. This caused massive memory allocation overhead and severe garbage collection (GC) churn on every iteration, leading to significant performance degradation in the consolidation engine's duplicate reduction step.

📊 **Impact:** Completely eliminates unnecessary array allocation and object creation inside an $O(n^2)$ loop, significantly reducing peak memory usage and garbage collection overhead, making the vector clustering phase noticeably faster.

🔬 **Measurement:** Compile with `pnpm run build` and run `pnpm test` to verify logic holds. If possible, a memory profiler (like Node's `--inspect`) would show a dramatic drop in temporary array allocations during the deduplication phase.

---
*PR created automatically by Jules for task [11873481169652850690](https://jules.google.com/task/11873481169652850690) started by @giauphan*