### PR TITLE
feat: add missing /api/keys CRUD routes

### DIFF
--- a/src/presentation/httpServer.ts
+++ b/src/presentation/httpServer.ts
@@ -5,13 +5,13 @@ import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import * as fs from "fs";
 import * as path from "path";
 import { getApps } from "firebase-admin/app";
-import { getFirestore } from "firebase-admin/firestore";
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
 import { checkAuth, logActivity } from "../services/authService.js";
 import { authMiddleware } from "../middleware/auth.js";
-import { 
-  discoverProjectsAsync, 
-  loadAnalysisAsync, 
-  getStats, 
+import {
+  discoverProjectsAsync,
+  loadAnalysisAsync,
+  getStats,
   fileExists,
   resolveProjectDir,
   unregisterProject
@@ -29,6 +29,7 @@ import { mountCronSettingsRoutes } from "./cronSettingsRoute.js";
 import { authProxyRouter } from "../routes/authProxy.js";
 import { a2aExecutor } from "./a2a/a2aExecutor.js";
 import { logger } from "../utils/logger.js";
+import * as crypto from "crypto";
 
 // Wrapper object to allow clean mocking of Firebase services in testing environments
 export const firebaseClient = {
@@ -619,6 +620,65 @@ app.get("/api/version", (_req, res) => {
   res.json({ version, buildTime: Date.now() });
 });
 
+// REST API: Manage API Keys (backend-proxied)
+app.get("/api/keys", authMiddleware, async (req, res) => {
+  try {
+    const auth = authStorage.getStore();
+    if (!auth) return res.status(401).json({ error: "Unauthorized" });
+
+    const db = firebaseClient.getFirestore();
+    const keysSnapshot = await db.collection('users').doc(auth.uid).collection('keys').get();
+    const keys = keysSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    res.json(keys);
+  } catch (err: unknown) {
+    logger.error("[API Keys] Failed to fetch keys:", err);
+    res.status(500).json({ error: "Failed to fetch API keys" });
+  }
+});
+
+app.post("/api/keys", authMiddleware, async (req, res) => {
+  try {
+    const auth = authStorage.getStore();
+    if (!auth) return res.status(401).json({ error: "Unauthorized" });
+
+    const newKey = `ca_${crypto.randomBytes(16).toString('hex')}`; // Prefix with 'ca_' for CodeAtlas API Key
+    const newKeyHash = crypto.createHash('sha256').update(newKey).digest('hex');
+
+    const db = firebaseClient.getFirestore();
+    const keyRef = db.collection('users').doc(auth.uid).collection('keys').doc();
+    await keyRef.set({
+      keyHash: newKeyHash,
+      createdAt: FieldValue.serverTimestamp(),
+      lastUsed: FieldValue.serverTimestamp(),
+      tier: auth.tier,
+      uid: auth.uid,
+      name: `API Key ${new Date().toLocaleString()}`, // Default name
+    });
+
+    res.json({ success: true, key: newKey, id: keyRef.id });
+  } catch (err: unknown) {
+    logger.error("[API Keys] Failed to create key:", err);
+    res.status(500).json({ error: "Failed to create API key" });
+  }
+});
+
+app.delete("/api/keys/:id", authMiddleware, async (req, res) => {
+  try {
+    const auth = authStorage.getStore();
+    if (!auth) return res.status(401).json({ error: "Unauthorized" });
+
+    const keyId = req.params.id;
+    const db = firebaseClient.getFirestore();
+    const keyRef = db.collection('users').doc(auth.uid).collection('keys').doc(keyId);
+    await keyRef.delete();
+
+    res.json({ success: true, id: keyId });
+  } catch (err: unknown) {
+    logger.error("[API Keys] Failed to delete key:", err);
+    res.status(500).json({ error: "Failed to delete API key" });
+  }
+});
+
 // REST API: Get analysis data
 app.get("/api/analysis", authMiddleware, async (req, res) => {
   try {
@@ -838,7 +898,7 @@ if (fs.existsSync(dashboardDistPath)) {
   }));
   
   // Catch-all: serve index.html for all non-API, non-SSE, non-well-known routes (SPA routing)
-  app.get(/^\/(?!sse|messages|api|\.well-known).*/, (req, res) => {
+  app.get(/^\/(?!sse|messages|api|\.well-known|a2a).*/, (req, res) => {
     res.sendFile(path.join(dashboardDistPath, "index.html"), {
       cacheControl: false,
       headers: {

--- a/src/presentation/httpServer.ts
+++ b/src/presentation/httpServer.ts
@@ -628,7 +628,12 @@ app.get("/api/keys", authMiddleware, async (req, res) => {
 
     const db = firebaseClient.getFirestore();
     const keysSnapshot = await db.collection('users').doc(auth.uid).collection('keys').get();
-    const keys = keysSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    const keys = keysSnapshot.docs.map(doc => {
+      const data = doc.data();
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { keyHash, ...safeData } = data; // Omit keyHash
+      return { id: doc.id, ...safeData };
+    });
     res.json(keys);
   } catch (err: unknown) {
     logger.error("[API Keys] Failed to fetch keys:", err);
@@ -641,7 +646,7 @@ app.post("/api/keys", authMiddleware, async (req, res) => {
     const auth = authStorage.getStore();
     if (!auth) return res.status(401).json({ error: "Unauthorized" });
 
-    const newKey = `ca_${crypto.randomBytes(16).toString('hex')}`; // Prefix with 'ca_' for CodeAtlas API Key
+    const newKey = `ca_${crypto.randomBytes(16).toString('hex')}`;
     const newKeyHash = crypto.createHash('sha256').update(newKey).digest('hex');
 
     const db = firebaseClient.getFirestore();
@@ -649,10 +654,9 @@ app.post("/api/keys", authMiddleware, async (req, res) => {
     await keyRef.set({
       keyHash: newKeyHash,
       createdAt: FieldValue.serverTimestamp(),
-      lastUsed: FieldValue.serverTimestamp(),
       tier: auth.tier,
       uid: auth.uid,
-      name: `API Key ${new Date().toLocaleString()}`, // Default name
+      name: `API Key ${new Date().toISOString()}`,
     });
 
     res.json({ success: true, key: newKey, id: keyRef.id });
@@ -668,6 +672,10 @@ app.delete("/api/keys/:id", authMiddleware, async (req, res) => {
     if (!auth) return res.status(401).json({ error: "Unauthorized" });
 
     const keyId = req.params.id;
+    if (!keyId || typeof keyId !== 'string' || keyId.trim() === '') {
+        return res.status(400).json({ error: "Invalid API Key ID" });
+    }
+
     const db = firebaseClient.getFirestore();
     const keyRef = db.collection('users').doc(auth.uid).collection('keys').doc(keyId);
     await keyRef.delete();


### PR DESCRIPTION
## Summary

Adds the missing  routes that the dashboard frontend requires for API key management.

-  — list keys for authenticated user
-  — create new API key with  prefix
-  — delete a key

The dashboard was calling these endpoints but they didn't exist on the server, causing 404 errors.

Closes the {"error":"Unauthorized: API Key is required. Set CODEATLAS_API_KEY env var or provide x-api-key header."}<!DOCTYPE html><html><head><script>window.onload=function(){window.location.href="/lander"}</script></head></html> error.