### PR TITLE
🎨 Palette: Add aria-label to knowledge graph search input

### DIFF
--- a/dashboard/src/components/KnowledgeGraphView.tsx
+++ b/dashboard/src/components/KnowledgeGraphView.tsx
@@ -88,6 +88,7 @@ export const KnowledgeGraphView: React.FC<KnowledgeGraphViewProps> = ({
               value={searchQuery}
               onChange={e => setSearchQuery(e.target.value)}
               placeholder="Search sphere…"
+              aria-label="Search knowledge graph sphere"
               style={{
                 width: '100%', padding: '0.6rem 1rem 0.6rem 2.8rem', borderRadius: '12px',
                 border: '1px solid rgba(255,255,255,0.15)', background: 'rgba(0,0,0,0.7)',


### PR DESCRIPTION
### 💡 What
Added an `aria-label="Search knowledge graph sphere"` attribute to the search input in the KnowledgeGraphView component.

### 🎯 Why
The input element relied entirely on placeholder text ("Search sphere…") for visual context but lacked a programmatic label. Adding an `aria-label` ensures screen readers can accurately announce the purpose of the input field to visually impaired users.

### 📸 Before/After
*   **Before:** `<input type="text" placeholder="Search sphere…" ... />`
*   **After:** `<input type="text" placeholder="Search sphere…" aria-label="Search knowledge graph sphere" ... />`

### ♿ Accessibility
Improved screen reader compatibility by explicitly labeling the search input, allowing users navigating via keyboard or assistive technologies to understand the field's purpose.

---
*PR created automatically by Jules for task [233703718583698115](https://jules.google.com/task/233703718583698115) started by @giauphan*