### PR TITLE
fix(auth): redact plaintext password from request body

### DIFF
--- a/src/routes/authProxy.ts
+++ b/src/routes/authProxy.ts
@@ -72,6 +72,11 @@ async function getAccessToken(): Promise<string> {
 router.post("/api/auth/signin", authRateLimiter, async (req, res) => {
   const { email, password } = req.body || {};
 
+  // Redact the password in the request body to prevent it from being logged down the line
+  if (req.body && req.body.password) {
+    req.body.password = "[REDACTED]";
+  }
+
   if (!email || !password) {
     return res.status(400).json({ error: "Email and password are required" });
   }


### PR DESCRIPTION
Resolves the issue of potential plaintext password logging by explicitly redacting the password in the request body in the sign-in endpoint. Tests have been run and passed successfully.

---
*PR created automatically by Jules for task [16488202673792997176](https://jules.google.com/task/16488202673792997176) started by @giauphan*