### PR TITLE
🧹 refactor(genomeRoutes): use strict Express types for sync-skills route

### DIFF
--- a/src/presentation/genomeRoutes.ts
+++ b/src/presentation/genomeRoutes.ts
@@ -193,7 +193,7 @@ export function mountGenomeRoutes(app: express.Application): void {
 
 
   // ── Auto-Sync: Hermes Skills -> Genome ───────────────────────
-  app.post("/api/genome/sync-skills", authMiddleware, async (req: any, res: any) => {
+  app.post("/api/genome/sync-skills", authMiddleware, async (req: express.Request, res: express.Response) => {
     try {
       const fs = await import("node:fs");
       const path = await import("node:path");


### PR DESCRIPTION
🎯 **What:** Replaced `(req: any, res: any)` with `(req: express.Request, res: express.Response)` in `/api/genome/sync-skills` route.
💡 **Why:** Loose typing reduces predictability and bypasses compiler checks. By explicitly tying the parameters to their Express types, we get better intellisense and enforce safe handling in future changes.
✅ **Verification:** Ran TypeScript compiler (`npm run build`) and the test suite (`npm test`), all checks passed successfully.
✨ **Result:** Improved static type safety and maintainability for the `sync-skills` endpoint.

---
*PR created automatically by Jules for task [352983057053137210](https://jules.google.com/task/352983057053137210) started by @giauphan*