### PR TITLE
🧹 redact password from req.body to prevent logging

### DIFF
--- a/src/routes/authProxy.ts
+++ b/src/routes/authProxy.ts
@@ -72,6 +72,10 @@ async function getAccessToken(): Promise<string> {
 router.post("/api/auth/signin", authRateLimiter, async (req, res) => {
   const { email, password } = req.body || {};
 
+  if (req.body && req.body.password) {
+    req.body.password = "[REDACTED]";
+  }
+
   if (!email || !password) {
     return res.status(400).json({ error: "Email and password are required" });
   }


### PR DESCRIPTION
This commit redacts the `password` field from `req.body` directly inside the `/api/auth/signin` route. 

🎯 **What:** Redacted the plaintext password from `req.body` right after extraction.
💡 **Why:** This ensures any subsequent middleware or error handlers that might inspect `req.body` won't log the user's plaintext password, addressing a security risk.
✅ **Verification:** Ran `npm run test` and verified all tests continue to pass. The application functionality relies on the extracted `password` variable, not the mutable `req.body` field afterwards.
✨ **Result:** Enhanced security by preventing inadvertent leakage of plaintext passwords in system logs.

---
*PR created automatically by Jules for task [8136227868636340592](https://jules.google.com/task/8136227868636340592) started by @giauphan*