### PR TITLE
⚡ Bolt: Replace O(n²) nested link search with O(1) hash map lookup in SecurityScanner

### DIFF
--- a/src/services/scanner/securityScanner.ts
+++ b/src/services/scanner/securityScanner.ts
@@ -21,6 +21,15 @@ export class SecurityScanner {
 
     const nodesMap = new Map(nodes.map((n: GraphNode) => [n.id, n]));
 
+    // Pre-compute an adjacency list to avoid O(N*L) lookups inside isSqlRelated
+    const linkMap = new Map<string, Set<string>>();
+    analysis.graph.links.forEach((link) => {
+      if (!linkMap.has(link.source)) linkMap.set(link.source, new Set());
+      if (!linkMap.has(link.target)) linkMap.set(link.target, new Set());
+      linkMap.get(link.source)!.add(link.target);
+      linkMap.get(link.target)!.add(link.source);
+    });
+
     const unsafeFuncs = [
       "eval",
       "exec",
@@ -153,15 +162,8 @@ export class SecurityScanner {
         return true;
       }
 
-      // 3. Check connected nodes (incoming / outgoing calls or imports)
-      const connectedNodeIds = new Set<string>();
-      analysis.graph.links.forEach((link) => {
-        if (link.source === node.id) {
-          connectedNodeIds.add(link.target);
-        } else if (link.target === node.id) {
-          connectedNodeIds.add(link.source);
-        }
-      });
+      // 3. Check connected nodes (incoming / outgoing calls or imports) using the pre-computed adjacency list
+      const connectedNodeIds = linkMap.get(node.id) || new Set<string>();
 
       for (const id of connectedNodeIds) {
         const otherNode = nodesMap.get(id);


### PR DESCRIPTION
💡 **What**: Pre-computed an adjacency list (`linkMap`) inside `SecurityScanner.scan` to replace a full traversal of the `analysis.graph.links` array for each node matching an SQL injection risk check.
🎯 **Why**: Previously, `isSqlRelated` executed an $O(L)$ loop to find connected links for each matched node, leading to $O(N \times L)$ time complexity where $N$ is the number of queried nodes and $L$ is the number of links in the graph. By using an adjacency list Map, the graph relationships are loaded once in $O(L)$ time, and subsequent lookups operate in $O(1)$ time, yielding an overall $O(N + L)$ performance scaling.
📊 **Impact**: This drastically improves scanning time for large enterprise codebase analyses, preventing the scanner thread from hanging on graphs with tens of thousands of links.
🔬 **Measurement**: Verify by running `npm test tests/unit/scanner.test.ts`. For large graphs, time `SecurityScanner.scan(analysis)` to observe the asymptotic time complexity improvement.

---
*PR created automatically by Jules for task [11977583812204784689](https://jules.google.com/task/11977583812204784689) started by @giauphan*