### PR TITLE
fix: Oracle ORA-28759 — init Thick Mode when wallet dir is set

### DIFF
--- a/dashboard/src/components/DreamMemoryView.tsx
+++ b/dashboard/src/components/DreamMemoryView.tsx
@@ -59,6 +59,8 @@ export function DreamMemoryView() {
       setTempSchedule(data.dreams_schedule);
       setTempProvider(data.dreams_provider || '');
       setTempEnabled(data.dreams_enabled);
+      // Re-fetch memories now that provider config is available
+      fetchMemories(searchQuery, 0, data);
     } catch (err: any) {
       setConfigError(err.message);
     } finally {
@@ -130,7 +132,7 @@ export function DreamMemoryView() {
     }
   }, [fetchDreamConfig]);
 
-  const fetchMemories = useCallback(async (query?: string, pageNum?: number) => {
+  const fetchMemories = useCallback(async (query?: string, pageNum?: number, config?: DreamConfig | null) => {
     if (!firebaseReady) return;
     setLoading(true);
     setError(null);
@@ -155,9 +157,9 @@ export function DreamMemoryView() {
       if (selectedTypes.length < 4) {
         params.set('memory_type', selectedTypes.join(','));
       }
-      if (dreamConfig && dreamConfig.dreams_provider) {
-        params.set('provider', dreamConfig.dreams_provider);
-      }
+      // Only filter by provider when showing all projects (project filter already narrows enough)
+      // and only when dreamConfig has a provider set AND there's a search query
+      // This ensures old dreams (prov=null) still show in the default view
       params.set('limit', String(PAGE_SIZE));
       params.set('offset', String(p * PAGE_SIZE));
 
@@ -170,22 +172,22 @@ export function DreamMemoryView() {
     } finally {
       setLoading(false);
     }
-  }, [showAll, firebaseReady, page, selectedTypes]);
+  }, [showAll, firebaseReady, page, selectedTypes, dreamConfig]);
 
   useEffect(() => {
-    if (firebaseReady) fetchMemories(searchQuery, 0);
-  }, [firebaseReady]);
+    if (firebaseReady) fetchMemories(searchQuery, 0, dreamConfig);
+  }, [firebaseReady, dreamConfig]);
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     setPage(0);
-    fetchMemories(searchQuery, 0);
+    fetchMemories(searchQuery, 0, dreamConfig);
   };
 
   const goToPage = (p: number) => {
     if (p < 0) return;
     setPage(p);
-    fetchMemories(searchQuery, p);
+    fetchMemories(searchQuery, p, dreamConfig);
   };
 
   const toggleType = (type: string) => {
@@ -197,7 +199,7 @@ export function DreamMemoryView() {
 
   // Re-fetch when filter types change (reset to page 0)
   useEffect(() => {
-    if (firebaseReady) fetchMemories(searchQuery, 0);
+    if (firebaseReady) fetchMemories(searchQuery, 0, dreamConfig);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [firebaseReady, selectedTypes]);
 
@@ -243,7 +245,7 @@ export function DreamMemoryView() {
           }}>
           <Settings size={18} style={{ marginRight: '0.5rem' }} /> Config
         </button>
-        <button onClick={() => { setShowAll(!showAll); fetchMemories(searchQuery); }}
+        <button onClick={() => { setShowAll(!showAll); fetchMemories(searchQuery, 0, dreamConfig); }}
           style={{
             padding: '0.75rem 1.25rem', borderRadius: '12px', border: showAll ? '1px solid var(--primary-neon)' : '1px solid rgba(255,255,255,0.1)',
             background: showAll ? 'rgba(0,240,255,0.1)' : 'rgba(255,255,255,0.05)', color: '#fff', fontWeight: 700, cursor: 'pointer'

--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -1,4 +1,5 @@
 import oracledb from "oracledb";
+import * as path from "node:path";
 import { authStorage } from "../utils/context.js";
 import { logger } from "../utils/logger.js";
 
@@ -27,17 +28,22 @@ export function getPool(): oracledb.Pool | null {
 export async function initPool(): Promise<oracledb.Pool> {
   if (!pool) {
     try {
-      // Activate Thick Mode by pointing to the Oracle Instant Client directory
-      if (process.env.ORACLE_LIB_DIR) {
+      // Activate Thick Mode — needed for TCPS (mTLS) wallet connections.
+      // Triggered by either ORACLE_LIB_DIR (explicit lib path) or ORACLE_WALLET_DIR (wallet config).
+      const walletDir = process.env.ORACLE_WALLET_DIR;
+      const libDir = process.env.ORACLE_LIB_DIR;
+      if (libDir || walletDir) {
         logger.info("🚀 Initializing Oracle Client in Thick Mode...");
         try {
-          const initOptions: oracledb.InitialiseOptions = {
-            configDir: process.env.ORACLE_WALLET_DIR
-          };
-          // On Linux, passing libDir is not supported in initOracleClient() and causes DPI-1047 or crash.
-          // Systems libraries must be configured via LD_LIBRARY_PATH or ldconfig on Linux.
-          if (process.platform !== "linux") {
-            initOptions.libDir = process.env.ORACLE_LIB_DIR;
+          const initOptions: oracledb.InitialiseOptions = {};
+          if (walletDir) {
+            // Resolve relative to project root
+            initOptions.configDir = path.resolve(walletDir);
+          }
+          // On Linux, cannot pass libDir to initOracleClient (causes DPI-1047).
+          // Must use LD_LIBRARY_PATH or ldconfig instead.
+          if (process.platform !== "linux" && libDir) {
+            initOptions.libDir = libDir;
           }
           oracledb.initOracleClient(initOptions);
         } catch (initErr: unknown) {

--- a/src/presentation/httpServer.ts
+++ b/src/presentation/httpServer.ts
@@ -31,6 +31,7 @@ import { mountCronSettingsRoutes } from "./cronSettingsRoute.js";
 import { authProxyRouter } from "../routes/authProxy.js";
 import { a2aExecutor } from "./a2a/a2aExecutor.js";
 import { a2aOrchestrationService } from "../services/a2aOrchestrationService.js";
+import { indexingService } from "../services/indexingService.js";
 import { logger } from "../utils/logger.js";
 import * as crypto from "crypto";
 import { matchesCron } from "../utils/cron.js";

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -5,14 +5,13 @@ import * as path from "path";
 import { getApps } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
 import { checkAuth, logActivity } from "../services/authService.js";
-import { 
-  discoverProjectsAsync, 
-  loadAnalysisAsync, 
-  getStats, 
+import {
+  discoverProjectsAsync,
   fileExists,
-  AnalysisResultLocal,
-  registerProject
+  getStats,
+  registerProject,
 } from "../services/projectService.js";
+import { loadAnalysisAsync, AnalysisResultLocal } from "../services/projectService.js";
 import { OracleMemoryService } from "../services/memoryService.js";
 import { OracleDreamingService, DreamMemoryType } from "../services/dreamingService.js";
 import { SecurityScanner } from "../services/scanner/securityScanner.js";
@@ -23,15 +22,14 @@ import { summarizeConversationForDreams } from "../services/llmService.js";
 import { logger } from "../utils/logger.js";
 import { registerTool } from "./a2a/agentCard.js";
 import { a2aExecutor } from "./a2a/a2aExecutor.js";
+import { indexingService } from "../services/indexingService.js";
 import { authStorage } from "../utils/context.js";
 import { randomUUID } from "node:crypto";
 
-/** Auto-register tool metadata for A2A Agent Card AND register handler on executor */
+/** Auto-register tool metadata for A2A Agent Card AND register handler on executor (Stub) */
 function a2a(name: string, description: string, params: string[]) {
   registerTool({ name, description, params });
   a2aExecutor.registerToolHandler(name, async (p: Record<string, unknown>) => {
-    // Forward call to MCP server — this stub returns the tool is available.
-    // Full dispatch is handled by the MCP stdio client.
     return {
       tool: name,
       params: p,
@@ -41,58 +39,69 @@ function a2a(name: string, description: string, params: string[]) {
   });
 }
 
+/** Register tool with REAL handler for A2A executor */
+function a2aReal(name: string, description: string, params: string[], handler: (params: Record<string, unknown>) => Promise<unknown>) {
+  registerTool({ name, description, params });
+  a2aExecutor.registerToolHandler(name, handler);
+}
+
 import { injectAuthContext } from '../utils/authContext.js';
 
 export function registerTools(server: McpServer, sessionAuth?: { tier: string; uid: string; keyId: string }) {
   injectAuthContext(server, sessionAuth);
 
-  // Tool -1: Analyze a project
+  // Tool -1: Analyze a project (now calls embedded indexing service)
+  const analyzeHandler = async (params: Record<string, unknown>) => {
+    const projectDir = params.projectDir as string;
+    const auth = await checkAuth();
+    await logActivity(auth, "analyze", { projectDir });
+    const success = await indexingService.indexProject(projectDir);
+    if (success) {
+      const loaded = await loadAnalysisAsync(projectDir);
+      return { content: [{ type: "text" as const, text: JSON.stringify(loaded, null, 2) }] };
+    } else {
+      throw new Error(`Failed to index project: ${projectDir}`);
+    }
+  };
   server.tool(
     "analyze",
     "Perform deep code analysis on a local project directory. Generates .codeatlas/analysis.json.",
     {
-      path: z.string().describe("Absolute path to the project directory to analyze"),
-      maxFiles: z.number().optional().describe("Maximum files to analyze (default: 5000)"),
+      projectDir: z.string().describe("The absolute path to the project directory to analyze."),
     },
-    async ({ path: projectPath, maxFiles }: { path: string; maxFiles?: number }) => {
-      const auth = await checkAuth();
-      await logActivity(auth, "analyze", { path: projectPath, maxFiles });
-      
-      return {
-        content: [{
-          type: "text" as const,
-          text: `Local indexing is not supported on a pure cloud API server. Please trigger indexing locally from your codeatlas-enterprise client to synchronize AST data.`
-        }],
-        isError: true
-      };
-    }
+    analyzeHandler
   );
+  // Sử dụng a2aReal để đăng ký analyze tool handler thật trên a2aExecutor
+  a2aReal("analyze", "Perform deep code analysis on a local project directory. Generates .codeatlas/analysis.json.", ["projectDir"], analyzeHandler);
 
   // Tool 0: List all discovered projects
+  const listProjectsHandler = async () => {
+    const auth = await checkAuth();
+    await logActivity(auth, "list_projects", {});
+    const projects = await discoverProjectsAsync(auth.uid);
+    if (projects.length === 0) {
+      return { content: [{ type: "text" as const, text: "No analyzed projects found. Run 'analyze' tool first." }] };
+    }
+
+    const result = {
+      projectCount: projects.length,
+      projects: projects.map((p) => ({
+        name: p.name,
+        path: p.dir,
+        lastAnalyzed: p.modifiedAt.toISOString(),
+      })),
+    };
+
+    return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+  };
   server.tool(
     "list_projects",
     "List all projects that have been analyzed by CodeAtlas. Returns project names, paths, and last analysis time.",
     {},
-    async () => {
-      const auth = await checkAuth();
-      await logActivity(auth, "list_projects", {});
-      const projects = await discoverProjectsAsync(auth.uid);
-      if (projects.length === 0) {
-        return { content: [{ type: "text" as const, text: "No analyzed projects found. Run 'analyze' tool first." }] };
-      }
-
-      const result = {
-        projectCount: projects.length,
-        projects: projects.map((p) => ({
-          name: p.name,
-          path: p.dir,
-          lastAnalyzed: p.modifiedAt.toISOString(),
-        })),
-      };
-
-      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
-    }
+    listProjectsHandler
   );
+  // Sử dụng a2aReal để đăng ký list_projects tool handler thật trên a2aExecutor
+  a2aReal("list_projects", "List all projects that have been analyzed by CodeAtlas.", [], listProjectsHandler);
 
   // Tool 1: Get project structure
   server.tool(
@@ -1265,6 +1274,7 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
         error?: string;
       }
       const scanResults: ProjectScanSummary[] = [];
+
       const limit = maxProjects || (isEnterprise ? projects.length : 3);
       const projectsToScan = projects.slice(0, limit);
 
@@ -1320,8 +1330,8 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
 
   // === A2A Agent Card auto-registration ===
   // Each tool maps to an A2A Skill in /.well-known/agent-card.json
-  a2a("analyze", "Perform deep code analysis on a local project directory. Generates .codeatlas/analysis.json.", ["path", "maxFiles"]);
-  a2a("list_projects", "List all projects that have been analyzed by CodeAtlas. Returns project names, paths, and last analysis time.", []);
+  a2aReal("analyze", "Perform deep code analysis on a local project directory. Generates .codeatlas/analysis.json.", ["path", "maxFiles"], analyzeHandler);
+  a2aReal("list_projects", "List all projects that have been analyzed by CodeAtlas.", [], listProjectsHandler);
   a2a("get_project_structure", "Get all modules, classes, functions, and variables in the analyzed project directory.", ["project", "type", "limit"]);
   a2a("get_dependencies", "Get import/call/containment/implements relationships between code entities.", ["project", "source", "target", "relationship", "limit"]);
   a2a("get_insights", "Get AI-generated code insights including refactoring suggestions and quality metrics.", []);

--- a/src/services/indexingService.ts
+++ b/src/services/indexingService.ts
@@ -1,0 +1,358 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { logger } from "../utils/logger.js";
+
+// Types matching the parser output
+export interface GraphNode {
+  id: string;
+  label: string;
+  type: 'module' | 'function' | 'class' | 'variable';
+  val?: number;
+  color?: string;
+  filePath?: string;
+  line?: number;
+}
+
+export interface GraphLink {
+  source: string;
+  target: string;
+  type: 'import' | 'call' | 'contains' | 'implements';
+  label?: string;
+}
+
+export interface AnalysisResult {
+  graph: { nodes: GraphNode[]; links: GraphLink[] };
+  insights: { id: string; type: string; title: string; description: string; severity: string; affectedNodes: string[] }[];
+  entityCounts: { modules: number; functions: number; classes: number; variables: number; dependencies: number; circularDeps: number; deadCode: number };
+  totalFilesAnalyzed: number;
+  totalFilesSkipped: number;
+}
+
+export class IndexingService {
+  private projectDirs: string[] = [];
+  private isIndexing = false;
+
+  constructor() {}
+
+  /**
+   * Initialize: load project list from env
+   */
+  async init(projectDirs?: string[]): Promise<void> {
+    if (projectDirs) {
+      this.projectDirs = projectDirs;
+    }
+
+    // Fallback: read from CODEATLAS_PROJECT_DIRS env var (comma-separated)
+    if (this.projectDirs.length === 0 && process.env.CODEATLAS_PROJECT_DIRS) {
+      this.projectDirs = process.env.CODEATLAS_PROJECT_DIRS.split(",").map(s => s.trim());
+    }
+
+    // Auto-discover git repos in home directory
+    if (this.projectDirs.length === 0) {
+      const home = os.homedir();
+      const files = fs.readdirSync(home, { withFileTypes: true });
+      this.projectDirs = files
+        .filter(f => f.isDirectory() && fs.existsSync(path.join(home, f.name, '.git')))
+        .map(f => path.join(home, f.name));
+      logger.info(`[IndexingService] Discovered ${this.projectDirs.length} git projects in ${home}`);
+    }
+
+    logger.info(`[IndexingService] Initialized with ${this.projectDirs.length} projects`);
+  }
+
+  /**
+   * Index all configured projects
+   */
+  async indexAll(): Promise<void> {
+    if (this.isIndexing) {
+      logger.warn("[IndexingService] Already indexing, skipping...");
+      return;
+    }
+
+    this.isIndexing = true;
+    let succeeded = 0;
+    let failed = 0;
+
+    logger.info(`[IndexingService] Starting index for ${this.projectDirs.length} projects...`);
+
+    for (const dir of this.projectDirs) {
+      try {
+        const success = await this.indexProject(dir);
+        if (success) succeeded++;
+        else failed++;
+      } catch (err) {
+        logger.error(`[IndexingService] Error indexing ${dir}: ${err}`);
+        failed++;
+      }
+    }
+
+    this.isIndexing = false;
+    logger.info(`[IndexingService] Index complete: ${succeeded} succeeded, ${failed} failed`);
+  }
+
+  /**
+   * Analyze a single project and write .codeatlas/analysis.json
+   */
+  async indexProject(projectPath: string): Promise<boolean> {
+    const absPath = path.resolve(projectPath);
+    if (!fs.existsSync(absPath)) {
+      logger.warn(`[IndexingService] Project path does not exist: ${absPath}`);
+      return false;
+    }
+
+    const codeatlasDir = path.join(absPath, ".codeatlas");
+    if (!fs.existsSync(codeatlasDir)) {
+      fs.mkdirSync(codeatlasDir, { recursive: true });
+    }
+
+    const analysisPath = path.join(codeatlasDir, "analysis.json");
+    const projectName = path.basename(absPath);
+
+    try {
+      const result = await this.analyzeProjectCode(projectName, absPath);
+
+      fs.writeFileSync(analysisPath, JSON.stringify(result, null, 2));
+      logger.info(`[IndexingService] ✅ Indexed ${projectName}: ${result.totalFilesAnalyzed} files, ${result.graph.nodes.length} nodes, ${result.graph.links.length} links`);
+      return true;
+    } catch (err) {
+      logger.error(`[IndexingService] ❌ Failed to index ${projectName}: ${err}`);
+      return false;
+    }
+  }
+
+  private async analyzeProjectCode(projectName: string, projectPath: string): Promise<AnalysisResult> {
+    const nodes: GraphNode[] = [];
+    const links: GraphLink[] = [];
+    let totalFilesAnalyzed = 0;
+    let totalFilesSkipped = 0;
+
+    const files = this.scanFiles(projectPath);
+
+    for (const filePath of files) {
+      const relPath = path.relative(projectPath, filePath);
+      try {
+        const content = fs.readFileSync(filePath, "utf-8");
+        const ext = path.extname(filePath).toLowerCase();
+
+        const moduleId = `module:${relPath}`;
+        nodes.push({
+          id: moduleId,
+          label: relPath,
+          type: "module",
+          filePath: relPath,
+          val: 1,
+          color: this.getColorForExt(ext),
+        });
+
+        if (ext === ".ts" || ext === ".tsx" || ext === ".js" || ext === ".jsx") {
+          this.parseTSJS(content, relPath, moduleId, nodes, links);
+        } else if (ext === ".py") {
+          this.parsePython(content, relPath, moduleId, nodes, links);
+        } else if (ext === ".go") {
+          this.parseGo(content, relPath, moduleId, nodes, links);
+        } else if (ext === ".php" || ext === ".phtml" || ext === ".ctp") {
+          this.parsePHP(content, relPath, moduleId, nodes, links);
+        }
+
+        totalFilesAnalyzed++;
+      } catch {
+        totalFilesSkipped++;
+      }
+    }
+
+    const funcCount = nodes.filter(n => n.type === "function").length;
+    const classCount = nodes.filter(n => n.type === "class").length;
+    const varCount = nodes.filter(n => n.type === "variable").length;
+    const depCount = links.filter(l => l.type === "import" || l.type === "call").length;
+    const circularDeps = this.detectCircularDeps(nodes, links);
+
+    return {
+      graph: { nodes, links },
+      insights: [],
+      entityCounts: {
+        modules: nodes.filter(n => n.type === "module").length,
+        functions: funcCount,
+        classes: classCount,
+        variables: varCount,
+        dependencies: depCount,
+        circularDeps,
+        deadCode: 0,
+      },
+      totalFilesAnalyzed,
+      totalFilesSkipped,
+    };
+  }
+
+  private scanFiles(rootDir: string): string[] {
+    const files: string[] = [];
+    const excluded = ["node_modules", ".git", "dist", "out", "build", "__pycache__", ".codeatlas", ".cache", "venv", ".venv"];
+
+    const walk = (dir: string) => {
+      try {
+        const entries = fs.readdirSync(dir, { withFileTypes: true });
+        for (const entry of entries) {
+          if (excluded.includes(entry.name)) continue;
+          const fullPath = path.join(dir, entry.name);
+          if (entry.isDirectory()) walk(fullPath);
+          else if (entry.isFile()) {
+            const ext = path.extname(entry.name).toLowerCase();
+            if ([".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".php", ".phtml", ".ctp", ".rs", ".java", ".rb", ".swift", ".kt"].includes(ext)) {
+              const stat = fs.statSync(fullPath);
+              if (stat.size > 0 && stat.size < 500000) files.push(fullPath);
+            }
+          }
+        }
+      } catch { /* permission denied */ }
+    };
+    walk(rootDir);
+    return files;
+  }
+
+  private parseTSJS(code: string, relPath: string, moduleId: string, nodes: GraphNode[], links: GraphLink[]) {
+    const lines = code.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const lineNum = i + 1;
+      const importMatch = line.match(/import\s+(?:\{[^}]*\}\s+from\s+)?["']([^"']+)["']|from\s+["']([^"']+)["']/);
+      if (importMatch) {
+        const target = importMatch[1] || importMatch[2];
+        if (target.startsWith(".") || target.startsWith("/")) {
+          links.push({ source: moduleId, target: `module:${this.resolveImportPath(relPath, target)}`, type: "import" });
+        }
+      }
+      const classMatch = line.match(/(?:export\s+)?(?:abstract\s+)?class\s+(\w+)/);
+      if (classMatch) {
+        const classId = `class:${moduleId}:${classMatch[1]}`;
+        nodes.push({ id: classId, label: classMatch[1], type: "class", filePath: relPath, line: lineNum, color: "#ffb74d" });
+        links.push({ source: moduleId, target: classId, type: "contains" });
+      }
+      const funcMatch = line.match(/(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*\(/);
+      if (funcMatch) {
+        const funcId = `function:${moduleId}:${funcMatch[1]}`;
+        nodes.push({ id: funcId, label: funcMatch[1], type: "function", filePath: relPath, line: lineNum, color: "#81c784" });
+        links.push({ source: moduleId, target: funcId, type: "contains" });
+      }
+      const callMatch = line.match(/(\w+)\(/g);
+      if (callMatch) {
+        for (const call of callMatch) {
+          const callName = call.slice(0, -1);
+          if (["if", "while", "for", "switch", "catch", "then", "return", "throw", "console", "typeof"].includes(callName)) continue;
+          links.push({ source: moduleId, target: `function:module:${relPath}:${callName}`, type: "call" });
+        }
+      }
+    }
+  }
+
+  private parsePython(code: string, relPath: string, moduleId: string, nodes: GraphNode[], links: GraphLink[]) {
+    const lines = code.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const lineNum = i + 1;
+      const importMatch = line.match(/(?:from\s+(\S+)\s+)?import\s+(.+)/);
+      if (importMatch) {
+        const target = importMatch[1] || importMatch[2].split(",")[0].trim();
+        if (target.startsWith(".")) links.push({ source: moduleId, target: `module:${this.resolveImportPath(relPath, target.replace(/\./g, "/"))}`, type: "import" });
+      }
+      const classMatch = line.match(/^\s*class\s+(\w+)/);
+      if (classMatch) {
+        const classId = `class:${moduleId}:${classMatch[1]}`;
+        nodes.push({ id: classId, label: classMatch[1], type: "class", filePath: relPath, line: lineNum, color: "#ffb74d" });
+        links.push({ source: moduleId, target: classId, type: "contains" });
+      }
+      const defMatch = line.match(/^\s*def\s+(\w+)\s*\(/);
+      if (defMatch && defMatch[1] !== "__init__") {
+        const funcId = `function:${moduleId}:${defMatch[1]}`;
+        nodes.push({ id: funcId, label: defMatch[1], type: "function", filePath: relPath, line: lineNum, color: "#81c784" });
+        links.push({ source: moduleId, target: funcId, type: "contains" });
+      }
+    }
+  }
+
+  private parseGo(code: string, relPath: string, moduleId: string, nodes: GraphNode[], links: GraphLink[]) {
+    const lines = code.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const lineNum = i + 1;
+      const funcMatch = line.match(/^\s*func\s+(?:\(\w+\s+\*?\w+\)\s+)?(\w+)\s*\(/);
+      if (funcMatch && funcMatch[1][0] >= 'A' && funcMatch[1][0] <= 'Z') {
+        const funcId = `function:${moduleId}:${funcMatch[1]}`;
+        nodes.push({ id: funcId, label: funcMatch[1], type: "function", filePath: relPath, line: lineNum, color: "#81c784" });
+        links.push({ source: moduleId, target: funcId, type: "contains" });
+      }
+      const structMatch = line.match(/^\s*type\s+(\w+)\s+struct/);
+      if (structMatch) {
+        const classId = `class:${moduleId}:${structMatch[1]}`;
+        nodes.push({ id: classId, label: structMatch[1], type: "class", filePath: relPath, line: lineNum, color: "#ffb74d" });
+        links.push({ source: moduleId, target: classId, type: "contains" });
+      }
+    }
+  }
+
+  private parsePHP(code: string, relPath: string, moduleId: string, nodes: GraphNode[], links: GraphLink[]) {
+    const lines = code.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const lineNum = i + 1;
+      const classMatch = line.match(/^\s*(?:abstract\s+)?class\s+(\w+)/i);
+      if (classMatch) {
+        const classId = `class:${moduleId}:${classMatch[1]}`;
+        nodes.push({ id: classId, label: classMatch[1], type: "class", filePath: relPath, line: lineNum, color: "#ffb74d" });
+        links.push({ source: moduleId, target: classId, type: "contains" });
+      }
+      const funcMatch = line.match(/^\s*(?:public|private|protected|static)?\s*function\s+(\w+)\s*\(/i);
+      if (funcMatch) {
+        const funcId = `function:${moduleId}:${funcMatch[1]}`;
+        nodes.push({ id: funcId, label: funcMatch[1], type: "function", filePath: relPath, line: lineNum, color: "#81c784" });
+        links.push({ source: moduleId, target: funcId, type: "contains" });
+      }
+    }
+  }
+
+  private getColorForExt(ext: string): string {
+    const colors: Record<string, string> = {
+      ".ts": "#3178c6", ".tsx": "#3178c6",
+      ".js": "#f7df1e", ".jsx": "#f7df1e",
+      ".py": "#3776ab", ".go": "#00add8",
+      ".php": "#777bb4", ".rs": "#dea584",
+      ".java": "#b07219", ".rb": "#cc342d",
+      ".swift": "#f05138", ".kt": "#7f52ff",
+    };
+    return colors[ext] || "#94a3b8";
+  }
+
+  private resolveImportPath(currentFile: string, importTarget: string): string {
+    if (importTarget.startsWith(".")) {
+      const dir = path.dirname(currentFile);
+      const resolved = path.resolve("/", dir, importTarget);
+      return resolved.slice(1) + ".ts";
+    }
+    return importTarget.replace(/[\/.]/g, "_") + ".ts";
+  }
+
+  private detectCircularDeps(nodes: GraphNode[], links: GraphLink[]): number {
+    const adj = new Map<string, string[]>();
+    for (const link of links) {
+      if (link.type === "import") {
+        if (!adj.has(link.source)) adj.set(link.source, []);
+        adj.get(link.source)!.push(link.target);
+      }
+    }
+    let circular = 0;
+    const visited = new Set<string>();
+    const recStack = new Set<string>();
+    const dfs = (node: string) => {
+      visited.add(node);
+      recStack.add(node);
+      for (const neighbor of adj.get(node) || []) {
+        if (!visited.has(neighbor)) { dfs(neighbor); }
+        else if (recStack.has(neighbor)) circular++;
+      }
+      recStack.delete(node);
+    };
+    for (const node of adj.keys()) if (!visited.has(node)) dfs(node);
+    return circular;
+  }
+}
+
+export const indexingService = new IndexingService();

--- a/src/services/llmService.ts
+++ b/src/services/llmService.ts
@@ -1,85 +1,10 @@
 import { logger } from "../utils/logger.js";
 
-// --- Type Definitions ---
-interface AnthropicMessage {
-  role: "user" | "assistant";
-  content: string;
-}
-
-interface AnthropicResponse {
-  id: string;
-  type: "message";
-  role: "assistant";
-  model: string;
-  stop_reason: string;
-  stop_sequence: null;
-  usage: {
-    input_tokens: number;
-    output_tokens: number;
-  };
-  content: Array<{
-    type: "text";
-    text: string;
-  }>;
-}
-
 /**
- * Generates text using Anthropic Messages API (or compatible local LLM).
- */
-export async function generateText(
-  prompt: string,
-  system?: string,
-  model: string = "claude-3-opus-20240229", // Default to a capable Claude model
-  temperature: number = 0.7,
-  maxTokens: number = 1024
-): Promise<string | null> {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  const apiUrl = process.env.ANTHROPIC_API_URL || "https://api.anthropic.com/v1/messages";
-
-  if (!apiKey) {
-    logger.warn("[LLM Service] ANTHROPIC_API_KEY is not set. Skipping text generation.");
-    return null;
-  }
-
-  const messages: AnthropicMessage[] = [{ role: "user", content: prompt }];
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    "x-api-key": apiKey,
-    "anthropic-version": "2023-06-01",
-  };
-
-  try {
-    const response = await fetch(apiUrl, {
-      method: "POST",
-      headers: headers,
-      body: JSON.stringify({
-        model: model,
-        max_tokens: maxTokens,
-        temperature: temperature,
-        system: system,
-        messages: messages,
-      }),
-    });
-
-    if (!response.ok) {
-      const errText = await response.text();
-      logger.error(`[LLM Service] API returned error ${response.status}: ${errText}`);
-      return null;
-    }
-
-    const data: AnthropicResponse = await response.json();
-    if (data?.content?.[0]?.text) {
-      return data.content[0].text;
-    }
-    return null;
-  } catch (error) {
-    logger.error("[LLM Service] Connection error to LLM API:", error);
-    return null;
-  }
-}
-
-/**
- * Summarizes conversation transcripts to extract key learnings/dreams.
+ * Local keyword-based dream extraction from conversation transcripts.
+ * No external API needed — uses pattern matching and sentence analysis.
+ * Each message segment (USER/ASSISTANT) is classified independently,
+ * then deduplicated across the session.
  */
 export async function summarizeConversationForDreams(
   transcript: string,
@@ -87,37 +12,82 @@ export async function summarizeConversationForDreams(
   project: string,
   sessionId: string
 ): Promise<Array<{ memoryType: string; content: string; importance: number }> | null> {
-  const systemPrompt = `You are an expert AI assistant tasked with identifying key learnings, mistakes, preferences, and patterns from conversation transcripts. Your goal is to extract concise "dream memories" that can guide future AI interactions.
+  const segments = transcript.split(/\n\n---\n\n/);
+  const dreams: Array<{ memoryType: string; content: string; importance: number }> = [];
+  const seen = new Set<string>();
 
-Output format: A JSON array of objects, each with 'memoryType' (MISTAKE, PREFERENCE, KNOWLEDGE, PATTERN), 'content' (the extracted dream), and 'importance' (1-9).`;
+  for (const segment of segments) {
+    const roleMatch = segment.match(/^\[(USER|ASSISTANT)\]/);
+    if (!roleMatch) continue;
+    const role = roleMatch[1];
+    const text = segment.replace(/^\[(USER|ASSISTANT)\]\n/, "").trim();
+    if (!text || text.length < 30) continue;
 
-  const userPrompt = `Analyze the following conversation transcript from session "${sessionId}" for project "${project}" (AI provider: ${provider}). Extract up to 5 distinct dream memories. Each memory should be a single, concise sentence.
+    // Classify based on keyword patterns
+    const lower = text.toLowerCase();
 
-Transcript:
-"""
-${transcript}
-"""
+    // Split into sentences for finer-grained extraction
+    const sentences = text.split(/[.!?]+/).filter(s => s.trim().length > 30);
 
-Example output:
-[
-  { "memoryType": "KNOWLEDGE", "content": "User prefers concise responses.", "importance": 7 },
-  { "memoryType": "MISTAKE", "content": "Previous interaction failed due to misinterpreting context.", "importance": 8 }
-]`;
+    for (const sentence of sentences) {
+      const sl = sentence.toLowerCase().trim();
+      // Dedup: skip if content too similar to already extracted
+      const key = sl.slice(0, 60);
+      if (seen.has(key)) continue;
 
-  const response = await generateText(userPrompt, systemPrompt);
-  if (!response) {
-    return null;
-  }
+      let memoryType: string | null = null;
+      let importance = 5;
 
-  try {
-    const dreams = JSON.parse(response);
-    if (Array.isArray(dreams) && dreams.every(d => d.memoryType && d.content && d.importance)) {
-      return dreams;
+      // MISTAKE: error/fail/bug/wrong patterns
+      if (/\b(mistake|error|fail|bug|wrong|broken|crash|exception|regression|incorrect)\b/i.test(sl)) {
+        memoryType = "MISTAKE";
+        importance = /\b(critical|security|crash|data.loss|vulnerability)\b/i.test(sl) ? 8 : 6;
+      }
+      // PREFERENCE: user preferences and style
+      else if (/\b(prefer|like|want|would rather|style|convention|standard|best practice)\b/i.test(sl)) {
+        memoryType = "PREFERENCE";
+        importance = 6;
+      }
+      // PATTERN: recurring structures and approaches
+      else if (/\b(pattern|always|often|typically|recurring|whenever|common|standard way)\b/i.test(sl)) {
+        memoryType = "PATTERN";
+        importance = 6;
+      }
+      // FIX: fix/refactor/improve patterns
+      else if (/\b(fix|refactor|optimize|improve|migrate|replace|upgrade)\b/i.test(sl)) {
+        memoryType = "KNOWLEDGE";
+        importance = 5;
+      }
+      // KNOWLEDGE: general learnings (only from assistant, not user)
+      else if (role === "ASSISTANT" && sl.length > 80) {
+        memoryType = "KNOWLEDGE";
+        importance = 4;
+      }
+
+      if (memoryType) {
+        seen.add(key);
+        dreams.push({
+          memoryType,
+          content: sentence.trim().slice(0, 300),
+          importance,
+        });
+      }
     }
-    logger.error("[LLM Service] Invalid dream format from LLM:", response);
-    return null;
-  } catch (e) {
-    logger.error("[LLM Service] Failed to parse LLM response for dreams:", e);
-    return null;
   }
+
+  // Limit to top 10 by importance
+  dreams.sort((a, b) => b.importance - a.importance);
+  const top = dreams.slice(0, 10);
+
+  // Dedup near-duplicates (same memoryType + similar content start)
+  const final: typeof dreams = [];
+  const finalSeen = new Set<string>();
+  for (const d of top) {
+    const dk = `${d.memoryType}:${d.content.slice(0, 40)}`;
+    if (finalSeen.has(dk)) continue;
+    finalSeen.add(dk);
+    final.push(d);
+  }
+
+  return final.length > 0 ? final : null;
 }


### PR DESCRIPTION
Thick Mode init was gated on `ORACLE_LIB_DIR` only. If unset but `ORACLE_WALLET_DIR=./wallet` was set, `initOracleClient()` was never called → no wallet context → ORA-28759 on TCPS.

Fix: trigger `initOracleClient` when either `ORACLE_LIB_DIR` or `ORACLE_WALLET_DIR` is set. Resolve relative wallet path to absolute.