### PR TITLE
🎨 Palette: Add aria-label and title to fullscreen toggle button

### DIFF
--- a/dashboard/src/components/KnowledgeGraphView.tsx
+++ b/dashboard/src/components/KnowledgeGraphView.tsx
@@ -152,6 +152,8 @@ export const KnowledgeGraphView: React.FC<KnowledgeGraphViewProps> = ({
         <div style={{ position: 'absolute', bottom: '1.5rem', right: '1.5rem', zIndex: 10 }}>
           <button
             onClick={() => setIsFullscreen(!isFullscreen)}
+            aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+            title={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
             style={{
               padding: '0.5rem', borderRadius: '8px', border: '1px solid rgba(255,255,255,0.15)',
               background: 'rgba(0,0,0,0.7)', color: '#fff', cursor: 'pointer',


### PR DESCRIPTION
💡 **What**: Added `aria-label` and `title` attributes to the fullscreen toggle icon-only button in the Knowledge Graph View.
🎯 **Why**: To provide clear interaction context. Screen reader users can now hear what the button does instead of generic "button" or just reading the icon component out. Hovering over the button will also provide a native tooltip for mouse users, letting them know the button's action.
📸 **Before/After**: Visually unchanged aside from native tooltip on hover.
♿ **Accessibility**: Added `aria-label` and `title` to an icon-only button, addressing WCAG 2.1 Success Criterion 4.1.2 Name, Role, Value.

---
*PR created automatically by Jules for task [9423605708227721076](https://jules.google.com/task/9423605708227721076) started by @giauphan*