### PR TITLE
🎨 Palette: Add accessibility attributes to Knowledge Graph fullscreen toggle

### DIFF
--- a/dashboard/src/components/KnowledgeGraphView.tsx
+++ b/dashboard/src/components/KnowledgeGraphView.tsx
@@ -152,6 +152,8 @@ export const KnowledgeGraphView: React.FC<KnowledgeGraphViewProps> = ({
         <div style={{ position: 'absolute', bottom: '1.5rem', right: '1.5rem', zIndex: 10 }}>
           <button
             onClick={() => setIsFullscreen(!isFullscreen)}
+            aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+            title={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
             style={{
               padding: '0.5rem', borderRadius: '8px', border: '1px solid rgba(255,255,255,0.15)',
               background: 'rgba(0,0,0,0.7)', color: '#fff', cursor: 'pointer',


### PR DESCRIPTION
**💡 What:** Added dynamic `aria-label` and `title` attributes to the fullscreen toggle button in the Knowledge Graph view.
**🎯 Why:** The icon-only button (Minimize/Maximize) lacked clear labels, making it difficult for screen reader users to understand its purpose and preventing a helpful native tooltip from appearing for mouse users.
**📸 Before/After:** Before, the button just rendered an icon. After, it has `aria-label` and `title` attributes that dynamically swap between "Enter fullscreen" and "Exit fullscreen" based on the current state.
**♿ Accessibility:** Greatly improves screen reader accessibility by providing an explicit, state-aware label for an icon-only control.

---
*PR created automatically by Jules for task [264135266929090604](https://jules.google.com/task/264135266929090604) started by @giauphan*