### PR TITLE
⚡ Bolt: Refactor agentCard file reads to use asynchronous implementations

### DIFF
--- a/src/presentation/a2a/a2aRoutes.ts
+++ b/src/presentation/a2a/a2aRoutes.ts
@@ -16,15 +16,23 @@ import { authMiddleware } from "../../middleware/auth.js";
 
 export function mountA2ARoutes(app: express.Express, executor: A2AExecutor, baseUrl: string): void {
   // === Agent Discovery ===
-  app.get("/.well-known/agent-card.json", authMiddleware, async (_req, res) => {
-    const card = await buildAgentCard(baseUrl);
-    res.json(card);
+  app.get("/.well-known/agent-card.json", authMiddleware, async (_req, res, next) => {
+    try {
+      const card = await buildAgentCard(baseUrl);
+      res.json(card);
+    } catch (err) {
+      next(err);
+    }
   });
 
   // Also serve at alternate path for compatibility
-  app.get("/a2a/agent-card", authMiddleware, async (_req, res) => {
-    const card = await buildAgentCard(baseUrl);
-    res.json(card);
+  app.get("/a2a/agent-card", authMiddleware, async (_req, res, next) => {
+    try {
+      const card = await buildAgentCard(baseUrl);
+      res.json(card);
+    } catch (err) {
+      next(err);
+    }
   });
 
   // === JSON-RPC 2.0 Endpoint ===

--- a/src/presentation/a2a/a2aRoutes.ts
+++ b/src/presentation/a2a/a2aRoutes.ts
@@ -16,14 +16,14 @@ import { authMiddleware } from "../../middleware/auth.js";
 
 export function mountA2ARoutes(app: express.Express, executor: A2AExecutor, baseUrl: string): void {
   // === Agent Discovery ===
-  app.get("/.well-known/agent-card.json", authMiddleware, (_req, res) => {
-    const card = buildAgentCard(baseUrl);
+  app.get("/.well-known/agent-card.json", authMiddleware, async (_req, res) => {
+    const card = await buildAgentCard(baseUrl);
     res.json(card);
   });
 
   // Also serve at alternate path for compatibility
-  app.get("/a2a/agent-card", authMiddleware, (_req, res) => {
-    const card = buildAgentCard(baseUrl);
+  app.get("/a2a/agent-card", authMiddleware, async (_req, res) => {
+    const card = await buildAgentCard(baseUrl);
     res.json(card);
   });
 

--- a/src/presentation/a2a/agentCard.ts
+++ b/src/presentation/a2a/agentCard.ts
@@ -5,7 +5,7 @@
  */
 
 import type { AgentCard, AgentSkill, MCPToolMeta } from "../../types/a2a.js";
-import * as fs from "fs";
+import { promises as fs } from "fs";
 import * as path from "path";
 
 // Global tool registry — populated by mcpTools.ts at registration time
@@ -84,7 +84,7 @@ async function getPackageVersion(): Promise<string> {
 
   try {
     const pkgPath = path.join(process.cwd(), "package.json");
-    const pkg = JSON.parse(await fs.promises.readFile(pkgPath, "utf-8"));
+    const pkg = JSON.parse(await fs.readFile(pkgPath, "utf-8"));
     const version = pkg.version || "unknown";
     cachedPackageVersion = version;
     return version;

--- a/src/presentation/a2a/agentCard.ts
+++ b/src/presentation/a2a/agentCard.ts
@@ -29,7 +29,7 @@ export function registerTool(meta: MCPToolMeta): void {
  * Build a fully-formed AgentCard from the current MCP tool registry.
  * @param baseUrl - The server's base URL (e.g. "http://localhost:3000")
  */
-export function buildAgentCard(baseUrl: string): AgentCard {
+export async function buildAgentCard(baseUrl: string): Promise<AgentCard> {
   const skills: AgentSkill[] = toolRegistry.map((t) => ({
     id: t.name,
     name: t.name,
@@ -45,7 +45,7 @@ export function buildAgentCard(baseUrl: string): AgentCard {
       "AI-powered codebase intelligence platform — semantic code search, dependency graph analysis, " +
       "architectural smell detection, vulnerability scanning, and dreaming memory with vector search.",
     protocolVersion: "0.3.0",
-    version: getPackageVersion(),
+    version: await getPackageVersion(),
     url: `${baseUrl}/a2a/jsonrpc`,
     skills,
     capabilities: {
@@ -77,14 +77,14 @@ let cachedPackageVersion: string | undefined;
 /**
  * Read version from package.json (npm_package_version is only available in npm scripts).
  */
-function getPackageVersion(): string {
+async function getPackageVersion(): Promise<string> {
   if (cachedPackageVersion !== undefined) {
     return cachedPackageVersion;
   }
 
   try {
     const pkgPath = path.join(process.cwd(), "package.json");
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+    const pkg = JSON.parse(await fs.promises.readFile(pkgPath, "utf-8"));
     const version = pkg.version || "unknown";
     cachedPackageVersion = version;
     return version;


### PR DESCRIPTION
💡 What: Replaced `fs.readFileSync` with `fs.promises.readFile` when fetching the package version in `src/presentation/a2a/agentCard.ts`, and correctly cascaded the `async/await` updates to the API endpoints in `src/presentation/a2a/a2aRoutes.ts`.

🎯 Why: Reading files synchronously in Node.js server routes blocks the event loop while disk I/O completes. This causes event loop delays and prevents concurrent requests from being processed until the read is fully completed, heavily limiting scalability.

📊 Impact: Reduces maximum event loop delay, enabling concurrent JSON-RPC requests to process without being blocked by initial caching of the `package.json` read. Expected concurrency scales much better.

🔬 Measurement: Verify improvements using standard event loop delay concurrency testing tools by sending concurrent requests to the `/.well-known/agent-card.json` endpoint.

---
*PR created automatically by Jules for task [1513034441309160803](https://jules.google.com/task/1513034441309160803) started by @giauphan*