### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix API key bypass in mcpTools.ts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** Express app missing security headers (e.g. X-Powered-By exposed, missing XSS protection, etc.)
 **Learning:** Security headers are not enabled by default in Express and must be explicitly configured using middleware like helmet. Cross-origin configuration must be considered to avoid breaking existing CORS implementations.
 **Prevention:** Use helmet by default when initializing new Express applications and verify configuration against CORS needs.
+## 2026-07-24 - [Remove Hardcoded API Key Wildcard Bypass]
+**Vulnerability:** A hardcoded wildcard `*` was used as the `x-api-key` in a backend-to-backend `fetch` call within `src/presentation/mcpTools.ts` for the `sync_skills` endpoint.
+**Learning:** This bypass was likely introduced for convenience during testing or initial development, but hardcoded wildcards or bypass tokens violate the principle of least privilege and can allow unauthorized execution if standard API endpoints are exposed.
+**Prevention:** Internal/Server-to-Server API calls should dynamically reference actual secret tokens from environment variables (e.g., `process.env.CODEATLAS_API_KEY`) rather than relying on structural bypasses.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,7 @@
 **Vulnerability:** A hardcoded wildcard `*` was used as the `x-api-key` in a backend-to-backend `fetch` call within `src/presentation/mcpTools.ts` for the `sync_skills` endpoint.
 **Learning:** This bypass was likely introduced for convenience during testing or initial development, but hardcoded wildcards or bypass tokens violate the principle of least privilege and can allow unauthorized execution if standard API endpoints are exposed.
 **Prevention:** Internal/Server-to-Server API calls should dynamically reference actual secret tokens from environment variables (e.g., `process.env.CODEATLAS_API_KEY`) rather than relying on structural bypasses.
+## 2026-07-24 - [Fail Loudly on Missing Security Config]
+**Vulnerability:** A fallback to `""` was used when a required security environment variable (`CODEATLAS_API_KEY`) was missing.
+**Learning:** Silently falling back to invalid credentials masks configuration errors and can lead to obscure access denied responses (403s), making debugging difficult and potentially leaving endpoints in unexpected states.
+**Prevention:** When security configurations are mandatory, throw an explicit error early in the execution path to fail loudly and safely.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -15,3 +15,7 @@
 **Vulnerability:** A fallback to `""` was used when a required security environment variable (`CODEATLAS_API_KEY`) was missing.
 **Learning:** Silently falling back to invalid credentials masks configuration errors and can lead to obscure access denied responses (403s), making debugging difficult and potentially leaving endpoints in unexpected states.
 **Prevention:** When security configurations are mandatory, throw an explicit error early in the execution path to fail loudly and safely.
+## 2026-07-24 - [Handle HTTP Error States Before Parsing JSON]
+**Vulnerability:** A missing HTTP status check (`!res.ok`) before calling `res.json()` could lead to unhelpful JSON parse exceptions if the server returned a non-2xx status (e.g., a 401 or 500 error page).
+**Learning:** Assuming that an HTTP response will always be JSON when the status code indicates an error masks the true nature of the failure. This makes diagnosing API or authentication failures difficult, especially when interacting with internal secure endpoints.
+**Prevention:** Always check `!res.ok` (or equivalent status logic) immediately after a `fetch` request, and throw a descriptive error containing the status code and text *before* attempting to parse the response body as JSON.

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -1448,7 +1448,7 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
         method: "POST", headers: { "Content-Type": "application/json", "x-api-key": apiKey }
       });
       if (!res.ok) {
-        throw new Error(`Sync failed (${res.status}) on port ${port}: ${res.statusText}`);
+        throw new Error(`Sync failed (${res.status}) for ${res.url}: ${res.statusText}`);
       }
 
       const data = await res.json();

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -1440,8 +1440,11 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
     const auth = await checkAuth();
     await logActivity(auth, "sync_skills", {});
     try {
+      const apiKey = process.env.CODEATLAS_API_KEY;
+      if (!apiKey) throw new Error("CODEATLAS_API_KEY not configured");
+
       const res = await fetch(`http://localhost:${process.env.PORT || 8080}/api/genome/sync-skills`, {
-        method: "POST", headers: { "Content-Type": "application/json", "x-api-key": process.env.CODEATLAS_API_KEY || "" }
+        method: "POST", headers: { "Content-Type": "application/json", "x-api-key": apiKey }
       });
       const data = await res.json();
       return { content: [{ type: "text" as const, text: "Synced " + (data.synced || 0) + " skills" }] };

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -1443,10 +1443,14 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
       const apiKey = process.env.CODEATLAS_API_KEY;
       if (!apiKey) throw new Error("CODEATLAS_API_KEY not configured");
 
-      const res = await fetch(`http://localhost:${process.env.PORT || 8080}/api/genome/sync-skills`, {
+      const port = process.env.PORT || 8080;
+      const res = await fetch(`http://localhost:${port}/api/genome/sync-skills`, {
         method: "POST", headers: { "Content-Type": "application/json", "x-api-key": apiKey }
       });
-      if (!res.ok) throw new Error(`Sync failed with status: ${res.status} ${res.statusText}`);
+      if (!res.ok) {
+        const bodyText = await res.text().catch(() => "");
+        throw new Error(`Sync failed (${res.status}) on port ${port}: ${res.statusText}. Body: ${bodyText.slice(0, 200)}`);
+      }
 
       const data = await res.json();
       return { content: [{ type: "text" as const, text: "Synced " + (data.synced || 0) + " skills" }] };

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -1443,8 +1443,7 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
       const apiKey = process.env.CODEATLAS_API_KEY;
       if (!apiKey) throw new Error("CODEATLAS_API_KEY not configured");
 
-      const port = process.env.PORT || 8080;
-      const res = await fetch(`http://localhost:${port}/api/genome/sync-skills`, {
+      const res = await fetch(`http://localhost:${process.env.PORT || 8080}/api/genome/sync-skills`, {
         method: "POST", headers: { "Content-Type": "application/json", "x-api-key": apiKey }
       });
       if (!res.ok) {

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -1446,6 +1446,8 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
       const res = await fetch(`http://localhost:${process.env.PORT || 8080}/api/genome/sync-skills`, {
         method: "POST", headers: { "Content-Type": "application/json", "x-api-key": apiKey }
       });
+      if (!res.ok) throw new Error(`Sync failed with status: ${res.status} ${res.statusText}`);
+
       const data = await res.json();
       return { content: [{ type: "text" as const, text: "Synced " + (data.synced || 0) + " skills" }] };
     } catch (err) {

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -1440,8 +1440,8 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
     const auth = await checkAuth();
     await logActivity(auth, "sync_skills", {});
     try {
-      const res = await fetch("http://localhost:${process.env.PORT || 8080}/api/genome/sync-skills", {
-        method: "POST", headers: { "Content-Type": "application/json", "x-api-key": "*" }
+      const res = await fetch(`http://localhost:${process.env.PORT || 8080}/api/genome/sync-skills`, {
+        method: "POST", headers: { "Content-Type": "application/json", "x-api-key": process.env.CODEATLAS_API_KEY || "" }
       });
       const data = await res.json();
       return { content: [{ type: "text" as const, text: "Synced " + (data.synced || 0) + " skills" }] };

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -1448,8 +1448,7 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
         method: "POST", headers: { "Content-Type": "application/json", "x-api-key": apiKey }
       });
       if (!res.ok) {
-        const bodyText = await res.text().catch(() => "");
-        throw new Error(`Sync failed (${res.status}) on port ${port}: ${res.statusText}. Body: ${bodyText.slice(0, 200)}`);
+        throw new Error(`Sync failed (${res.status}) on port ${port}: ${res.statusText}`);
       }
 
       const data = await res.json();


### PR DESCRIPTION
🚨 **Severity:** CRITICAL

💡 **Vulnerability:** 
The `sync_skills` tool inside `src/presentation/mcpTools.ts` made an HTTP POST request to the local `/api/genome/sync-skills` endpoint using a hardcoded wildcard API key (`"x-api-key": "*"`). Additionally, the URL was wrapped in double quotes rather than backticks, resulting in literal string interpolation failure for the port variable.

🎯 **Impact:** 
Using a wildcard for an API key bypasses the authentication/authorization mechanisms entirely. If an attacker could trigger this logic or if the backend mistakenly accepts wildcards, it could lead to unauthorized actions. The interpolation bug also caused the fetch call to fail since it was trying to connect to a literally invalid URL string rather than interpolating the proper port.

🔧 **Fix:** 
1. Replaced the double quotes with backticks around the URL string in the fetch call to allow string interpolation to function properly.
2. Replaced the hardcoded wildcard `"*"` with the dynamically loaded environment variable `process.env.CODEATLAS_API_KEY || ""`.

✅ **Verification:** 
- Successfully ran `pnpm test` (dashboard pre-existing failures only).
- Verified `pnpm build` completes without TypeScript errors.

---
*PR created automatically by Jules for task [12532404900634504822](https://jules.google.com/task/12532404900634504822) started by @giauphan*