### PR TITLE
⚡ Bolt: Replace synchronous unregisterProject with async in Express API

### DIFF
--- a/src/presentation/httpServer.ts
+++ b/src/presentation/httpServer.ts
@@ -17,7 +17,8 @@ import {
   getStats,
   fileExists,
   resolveProjectDir,
-  unregisterProject
+  unregisterProject,
+  unregisterProjectAsync
 } from "../services/projectService.js";
 import { authStorage } from "../utils/context.js";
 import { registerTools } from "./mcpTools.js";
@@ -408,7 +409,7 @@ app.delete("/api/projects", authMiddleware, async (req, res) => {
     // 4. Unregister project from local registered list only if local cleanup was successful, or if force is enabled
     if (errors.length === 0 || isForce) {
       try {
-        unregisterProject(fullProjectDir);
+        await unregisterProjectAsync(fullProjectDir);
       } catch (regErr: unknown) {
         errors.push(`Failed to unregister project: ${regErr instanceof Error ? regErr.message : String(regErr)}`);
       }

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -263,6 +263,34 @@ export function unregisterProject(dir: string): void {
   }
 }
 
+export async function unregisterProjectAsync(dir: string): Promise<void> {
+  try {
+    const homeDir = os.homedir();
+    const configDir = path.join(homeDir, ".codeatlas");
+    const regPath = path.join(configDir, "registered_projects.json");
+    if (await fileExists(regPath)) {
+      let projects: string[] = [];
+      try {
+        const data = await fs.promises.readFile(regPath, "utf-8");
+        projects = JSON.parse(data);
+      } catch {
+        projects = [];
+      }
+      if (Array.isArray(projects)) {
+        const absPath = path.resolve(dir);
+        const filtered = projects.filter((p) => p !== absPath);
+        if (filtered.length !== projects.length) {
+          await fs.promises.writeFile(regPath, JSON.stringify(filtered, null, 2));
+          logger.info(`[Project-Registry] 📝 Unregistered project (async): ${absPath}`);
+        }
+      }
+    }
+  } catch (err) {
+    logger.error(`[Project-Registry] ❌ Failed to unregister project (async): ${err}`);
+    throw err;
+  }
+}
+
 export function scanForCodeatlasProjects(parentDir: string): string[] {
   const discovered: string[] = [];
   try {


### PR DESCRIPTION
💡 What: Replaced the synchronous `unregisterProject` function used in the `DELETE /api/projects` Express route with an asynchronous `unregisterProjectAsync` implementation that utilizes `fs.promises`.
🎯 Why: Synchronous `fs` calls block the Node.js event loop, causing severe latency spikes for concurrent API requests. Making file operations asynchronous prevents thread starvation.
📊 Impact: Removes a blocking bottleneck during HTTP deletion operations, enabling true asynchronous concurrency across the Express server.
🔬 Measurement: Verify by stress testing the API while triggering deletions. The Node.js event loop will remain unblocked and other API responses won't experience delays.

---
*PR created automatically by Jules for task [359349468761734647](https://jules.google.com/task/359349468761734647) started by @giauphan*