### PR TITLE
🎨 Palette: Add ARIA label to Copy button

### DIFF
--- a/dashboard/src/components/DocumentationView.tsx
+++ b/dashboard/src/components/DocumentationView.tsx
@@ -29,6 +29,7 @@ export const DocumentationView: React.FC = () => {
 
   const renderCopyButton = (text: string, id: string) => (
     <button
+      aria-label="Copy code block"
       onClick={() => handleCopy(text, id)}
       style={{
         position: 'absolute',


### PR DESCRIPTION
💡 What: Added an `aria-label="Copy code block"` to the icon-only "Copy" button in `DocumentationView.tsx`.
🎯 Why: To improve accessibility by providing an accessible name for screen reader users when they navigate to the copy button.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: The button is now properly labeled for assistive technologies, allowing users to understand its function without relying on the visual icon.

---
*PR created automatically by Jules for task [12396742409838768458](https://jules.google.com/task/12396742409838768458) started by @giauphan*