### PR TITLE
🎨 Palette: [UX improvement] - Accessible Cloud Index accordion

### DIFF
--- a/dashboard/src/components/CloudIndexView.tsx
+++ b/dashboard/src/components/CloudIndexView.tsx
@@ -98,17 +98,12 @@ export const CloudIndexView: React.FC<CloudIndexViewProps> = ({
               <div>
                 <button
                   type="button"
+                  className="accordion-toggle"
                   aria-expanded={showAdvanced}
                   aria-controls="advanced-config-panel"
-                  style={{
-                    background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, outline: 'none',
-                    display: 'flex', alignItems: 'center', gap: '1rem', color: '#fff', fontWeight: 700
-                  }}
                   onClick={() => setShowAdvanced(!showAdvanced)}
-                  onFocus={(e) => { e.currentTarget.style.boxShadow = '0 0 0 2px var(--primary-neon)'; e.currentTarget.style.borderRadius = '4px'; }}
-                  onBlur={(e) => { e.currentTarget.style.boxShadow = 'none'; e.currentTarget.style.borderRadius = '0'; }}
                 >
-                  <motion.div animate={{ rotate: showAdvanced ? 90 : 0 }} style={{ display: 'inline-block' }}>{"> "}</motion.div> Advanced Configuration
+                  <motion.div animate={{ rotate: showAdvanced ? 90 : 0 }}>{"> "}</motion.div> Advanced Configuration
                 </button>
               </div>
 

--- a/dashboard/src/components/CloudIndexView.tsx
+++ b/dashboard/src/components/CloudIndexView.tsx
@@ -95,20 +95,25 @@ export const CloudIndexView: React.FC<CloudIndexViewProps> = ({
             </div>
 
             <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
-              <div style={{ cursor: 'pointer' }} onClick={() => setShowAdvanced(!showAdvanced)}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', color: '#fff', fontWeight: 700 }}>
-                  <motion.div animate={{ rotate: showAdvanced ? 90 : 0 }}>{"> "}</motion.div> Setup Information
-                </div>
-              </div>
-              
-              <div style={{ cursor: 'pointer' }} onClick={() => setShowAdvanced(!showAdvanced)}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', color: '#fff', fontWeight: 700 }}>
-                  <motion.div animate={{ rotate: showAdvanced ? 90 : 0 }}>{"> "}</motion.div> Advanced Configuration
-                </div>
+              <div>
+                <button
+                  type="button"
+                  aria-expanded={showAdvanced}
+                  aria-controls="advanced-config-panel"
+                  style={{
+                    background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, outline: 'none',
+                    display: 'flex', alignItems: 'center', gap: '1rem', color: '#fff', fontWeight: 700
+                  }}
+                  onClick={() => setShowAdvanced(!showAdvanced)}
+                  onFocus={(e) => { e.currentTarget.style.boxShadow = '0 0 0 2px var(--primary-neon)'; e.currentTarget.style.borderRadius = '4px'; }}
+                  onBlur={(e) => { e.currentTarget.style.boxShadow = 'none'; e.currentTarget.style.borderRadius = '0'; }}
+                >
+                  <motion.div animate={{ rotate: showAdvanced ? 90 : 0 }} style={{ display: 'inline-block' }}>{"> "}</motion.div> Advanced Configuration
+                </button>
               </div>
 
               {showAdvanced && (
-                <motion.div initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: 'auto' }} style={{ padding: '1rem', background: 'rgba(0,0,0,0.2)', borderRadius: '12px', fontSize: '0.9rem', color: 'var(--text-muted)', lineHeight: 1.6 }}>
+                <motion.div id="advanced-config-panel" initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: 'auto' }} style={{ padding: '1rem', background: 'rgba(0,0,0,0.2)', borderRadius: '12px', fontSize: '0.9rem', color: 'var(--text-muted)', lineHeight: 1.6 }}>
                   Indexing Depth: Level 4 (Full Analysis)<br/>
                   Exclusions: node_modules, .git, build, dist<br/>
                   Target Directory: {analysis?.projectDir || 'active-workspace'}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -134,3 +134,24 @@ h1, h2, h3, .tech-font {
 .animate-bloom {
   animation: bloom 3s infinite ease-in-out;
 }
+
+/* Accessibility focus styles */
+.accordion-toggle {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  outline: none;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: #fff;
+  font-weight: 700;
+  border-radius: 4px;
+  transition: box-shadow 0.2s ease, border-radius 0.2s ease;
+}
+
+.accordion-toggle:focus-visible {
+  box-shadow: 0 0 0 2px var(--primary-neon);
+  border-radius: 4px;
+}


### PR DESCRIPTION
💡 What:
Replaced the `div` wrapper for the "Advanced Configuration" accordion in `CloudIndexView.tsx` with a native `button` tag. Removed an identically functioning duplicate toggle ("Setup Information") that existed right above it. Added `aria-expanded`, `aria-controls`, and `onFocus`/`onBlur` visual focus rings.

🎯 Why: 
Users navigating via keyboard could not focus or interact with the accordion toggles because they were implemented using `div` elements. Additionally, screen readers could not interpret them as expandable buttons. The duplicate toggle was also confusing since both buttons did the exact same thing (toggled `showAdvanced`).

📸 Before/After:
Before: Two `div` toggles that could not be tab-focused.
After: One proper `button` toggle that shows a neon cyan focus ring when tabbed to, indicating it is active.

♿ Accessibility:
- Changed `div` to `button type="button"`.
- Added `aria-expanded` tied to the component's state.
- Added `aria-controls` tied to the panel `id`.
- Added visual focus indicators using `onFocus` and `onBlur`.

---
*PR created automatically by Jules for task [2337772391922815499](https://jules.google.com/task/2337772391922815499) started by @giauphan*