### PR TITLE
🎨 Palette: Add ARIA attributes to OrchestrationTasks filter buttons

### DIFF
--- a/dashboard/src/components/OrchestrationTasksView.tsx
+++ b/dashboard/src/components/OrchestrationTasksView.tsx
@@ -122,11 +122,12 @@ export function OrchestrationTasksView() {
             }}
           />
         </div>
-        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+        <div role="group" aria-label="Filter tasks by state" style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
           {availableStates.map(state => (
             <button
               key={state}
               onClick={() => setFilterState(state)}
+              aria-pressed={filterState === state}
               style={{
                 padding: '0.5rem 1rem', borderRadius: '8px', border: '1px solid rgba(255,255,255,0.1)',
                 background: filterState === state ? 'rgba(0,240,255,0.15)' : 'rgba(0,0,0,0.2)',


### PR DESCRIPTION
💡 **What**: Added `aria-pressed` to the filter state buttons in `OrchestrationTasksView.tsx` to indicate active filter state, and added `role="group"` and `aria-label="Filter tasks by state"` to the parent container.

🎯 **Why**: To improve accessibility for screen readers, providing context about what the buttons do and which one is currently selected.

📸 **Before/After**: (No visual changes, purely accessibility and semantic HTML improvements).

♿ **Accessibility**: Converts standard buttons into properly semantic toggle buttons and groups them under a descriptive label.

---
*PR created automatically by Jules for task [4214468177560041561](https://jules.google.com/task/4214468177560041561) started by @giauphan*