### PR TITLE
⚡ Bolt: [performance improvement] Batch embedding generation

### DIFF
--- a/patch.cjs
+++ b/patch.cjs
@@ -1,0 +1,4 @@
+const fs = require('fs');
+let code = fs.readFileSync('src/services/consolidationEngine.ts', 'utf8');
+
+// Also add back the generateEmbedding import which was apparently used in the cosineSimilarity logic earlier... wait, the cosineSimilarity does not use generateEmbedding. Let's check where it is used.

--- a/patch.cjs
+++ b/patch.cjs
@@ -1,4 +1,0 @@
-const fs = require('fs');
-let code = fs.readFileSync('src/services/consolidationEngine.ts', 'utf8');
-
-// Also add back the generateEmbedding import which was apparently used in the cosineSimilarity logic earlier... wait, the cosineSimilarity does not use generateEmbedding. Let's check where it is used.

--- a/src/services/consolidationEngine.ts
+++ b/src/services/consolidationEngine.ts
@@ -10,7 +10,7 @@
 
 import { randomUUID } from "node:crypto";
 import { initPool, setSessionContext } from "../database/connection.js";
-import { generateEmbedding } from "./embeddingService.js";
+import { generateEmbedding, generateEmbeddingsBatch } from "./embeddingService.js";
 import { logger } from "../utils/logger.js";
 import { authStorage } from "../utils/context.js";
 import { OracleDreamingService } from "./dreamingService.js";
@@ -237,6 +237,14 @@ export class ConsolidationEngine {
 
       // Phase 1: Compute embeddings and prepare concept data
       const conceptsData: any[] = [];
+
+      const intermediateData: {
+        proj: string;
+        conceptLabel: string;
+        conceptDescription: string;
+        sources: string;
+      }[] = [];
+
       for (const [proj, group] of byProject) {
         // Take top 10 highest-importance dreams per project for concept extraction
         const topDreams = group.slice(0, 10);
@@ -247,20 +255,37 @@ export class ConsolidationEngine {
         // Generate a concept label and description from the content
         const conceptLabel = this.extractLabel(topDreams);
         const conceptDescription = combinedContent.slice(0, 1000);
-        const conceptEmbedding = await generateEmbedding(conceptDescription, "passage");
 
-        if (!conceptEmbedding || conceptEmbedding.length === 0) {
-          logger.warn(`[Consolidation] No embedding for concept "${conceptLabel}", skipping`);
-          continue;
-        }
-
-        conceptsData.push({
+        intermediateData.push({
           proj,
           conceptLabel,
           conceptDescription,
-          conceptEmbedding,
           sources: JSON.stringify(topDreams.map((d) => d[R_IDX.ID]))
         });
+      }
+
+      const descriptions = intermediateData.map(d => d.conceptDescription);
+      // ⚡ Bolt Optimization: Batch embedding generation to avoid N+1 API calls.
+      let batchEmbeddings: number[][] | null = null;
+      if (descriptions.length > 0) {
+        batchEmbeddings = await generateEmbeddingsBatch(descriptions, "passage");
+      }
+
+      if (batchEmbeddings) {
+        for (let i = 0; i < intermediateData.length; i++) {
+          const data = intermediateData[i];
+          const conceptEmbedding = batchEmbeddings[i];
+
+          if (!conceptEmbedding || conceptEmbedding.length === 0) {
+            logger.warn(`[Consolidation] No embedding for concept "${data.conceptLabel}", skipping`);
+            continue;
+          }
+
+          conceptsData.push({
+            ...data,
+            conceptEmbedding,
+          });
+        }
       }
 
       if (conceptsData.length > 0) {

--- a/src/services/consolidationEngine.ts
+++ b/src/services/consolidationEngine.ts
@@ -10,7 +10,7 @@
 
 import { randomUUID } from "node:crypto";
 import { initPool, setSessionContext } from "../database/connection.js";
-import { generateEmbedding, generateEmbeddingsBatch } from "./embeddingService.js";
+import { generateEmbeddingsBatch } from "./embeddingService.js";
 import { logger } from "../utils/logger.js";
 import { authStorage } from "../utils/context.js";
 import { OracleDreamingService } from "./dreamingService.js";
@@ -274,6 +274,12 @@ export class ConsolidationEngine {
       if (batchEmbeddings) {
         for (let i = 0; i < intermediateData.length; i++) {
           const data = intermediateData[i];
+
+          if (i >= batchEmbeddings.length) {
+            logger.warn(`[Consolidation] Batch returned fewer embeddings than requested. Missing embedding for "${data.conceptLabel}", skipping`);
+            continue;
+          }
+
           const conceptEmbedding = batchEmbeddings[i];
 
           if (!conceptEmbedding || conceptEmbedding.length === 0) {
@@ -286,6 +292,8 @@ export class ConsolidationEngine {
             conceptEmbedding,
           });
         }
+      } else if (intermediateData.length > 0) {
+        logger.warn(`[Consolidation] Batch embedding generation returned null for ${intermediateData.length} concepts, skipping`);
       }
 
       if (conceptsData.length > 0) {


### PR DESCRIPTION
💡 What: Replaced sequential `generateEmbedding` API calls inside a `for...of` loop with a single `generateEmbeddingsBatch` call in `ConsolidationEngine.extractConcepts`.
🎯 Why: To solve an N+1 API call performance bottleneck that was causing unnecessary network overhead and latency when extracting concepts.
📊 Impact: Reduces the number of API requests from N (number of concepts) to 1 (or batched in chunks of 50 by the service) when generating embeddings for newly extracted concepts.
🔬 Measurement: Verify by running a consolidation job that creates multiple concepts and observing the number of outbound network requests to the NVIDIA embeddings API.

---
*PR created automatically by Jules for task [10622432751853190257](https://jules.google.com/task/10622432751853190257) started by @giauphan*