### PR TITLE
🎨 Palette: [UX improvement] Add explicit ARIA roles to filter button groups and sidebar

### DIFF
--- a/dashboard/src/components/Dashboard.tsx
+++ b/dashboard/src/components/Dashboard.tsx
@@ -519,7 +519,7 @@ export const Dashboard: React.FC = () => {
       fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif'
     }}>
       {/* Sidebar Navigation */}
-      <nav style={{
+      <nav aria-label="Main Navigation" style={{
         width: '240px', background: 'var(--background-light)', padding: '2rem 1.5rem',
         display: 'flex', flexDirection: 'column', borderRight: '1px solid var(--border-color)'
       }}>
@@ -535,6 +535,7 @@ export const Dashboard: React.FC = () => {
               <li key={tab} style={{ marginBottom: '1rem' }}>
                 <button
                   onClick={() => setActiveTab(tab)}
+                  aria-current={activeTab === tab ? 'page' : undefined}
                   style={{
                     width: '100%', padding: '0.75rem 1rem', borderRadius: '8px',
                     background: activeTab === tab ? 'var(--button-active-background)' : 'transparent',

--- a/dashboard/src/components/DreamMemoryView.tsx
+++ b/dashboard/src/components/DreamMemoryView.tsx
@@ -339,7 +339,7 @@ export function DreamMemoryView() {
         </div>
       </div>
 
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1.5rem', flexWrap: 'wrap' }}>
+      <div role="group" aria-label="Filter by memory type" style={{ display: 'flex', gap: '0.5rem', marginBottom: '1.5rem', flexWrap: 'wrap' }}>
         {['KNOWLEDGE', 'PREFERENCE', 'MISTAKE', 'PATTERN'].map(type => (
           <button
             key={type}

--- a/dashboard/src/components/KnowledgeGraphView.tsx
+++ b/dashboard/src/components/KnowledgeGraphView.tsx
@@ -129,7 +129,7 @@ export const KnowledgeGraphView: React.FC<KnowledgeGraphViewProps> = ({
         </div>
 
         {/* Filter chips */}
-        <div style={{ position: 'absolute', top: '1.5rem', right: '1.5rem', zIndex: 10, display: 'flex', gap: '0.5rem' }}>
+        <div role="group" aria-label="Filter by entity type" style={{ position: 'absolute', top: '1.5rem', right: '1.5rem', zIndex: 10, display: 'flex', gap: '0.5rem' }}>
           {filters.map(f => (
             <button
               type="button"


### PR DESCRIPTION
💡 **What:** Added missing `role="group"` and `aria-label` to custom toggle button groups (e.g. filter chips) in the UI. Also added `aria-label="Main Navigation"` to the sidebar menu and `aria-current="page"` to the currently active item.
🎯 **Why:** Custom UI toggle buttons built using `aria-pressed` must explicitly be grouped together in a container with a `role="group"` or else screen readers will read them as unrelated, standalone buttons. `aria-current` clearly identifies the active view in sidebar navigation.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Fixes screen reader reading behavior for interactive filter chips and navigation menu across the app.

---
*PR created automatically by Jules for task [10126981261756029357](https://jules.google.com/task/10126981261756029357) started by @giauphan*