### PR TITLE
⚡ Bolt: [performance improvement] Refactor fs operations to use EAFP pattern

### DIFF
--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -535,10 +535,15 @@ export function discoverProjects(tenantId?: string): { name: string; dir: string
       try {
         const analysisPath = path.join(dir, ".codeatlas", "analysis.json");
         let modifiedAt: Date;
-        if (fs.existsSync(analysisPath)) {
+        // ⚡ Bolt: Use EAFP pattern to avoid redundant fs.existsSync system call overhead before statSync
+        try {
           modifiedAt = fs.statSync(analysisPath).mtime;
-        } else {
-          modifiedAt = fs.statSync(dir).mtime;
+        } catch (err: any) {
+          if (err.code === 'ENOENT') {
+            modifiedAt = fs.statSync(dir).mtime;
+          } else {
+            throw err;
+          }
         }
         projects.push({
           name: path.basename(dir),
@@ -597,11 +602,17 @@ export function loadAnalysis(projectDir?: string, force = false): { analysis: An
     if (onProjectLoadedCallback) {
       onProjectLoadedCallback(target.dir);
     }
-    if (!fs.existsSync(target.analysisPath)) {
-      logger.error(`[Auto-Scan] ❌ Dynamic sync scanning is not supported on the server repo. Please push analysis from MCP client: ${target.dir}`);
-      return null;
+    let data: string;
+    // ⚡ Bolt: Use EAFP pattern to avoid redundant fs.existsSync system call overhead before readFileSync
+    try {
+      data = fs.readFileSync(target.analysisPath, "utf-8");
+    } catch (err: any) {
+      if (err.code === 'ENOENT') {
+        logger.error(`[Auto-Scan] ❌ Dynamic sync scanning is not supported on the server repo. Please push analysis from MCP client: ${target.dir}`);
+        return null;
+      }
+      throw err;
     }
-    const data = fs.readFileSync(target.analysisPath, "utf-8");
     return { analysis: JSON.parse(data), projectName: target.name, projectDir: target.dir };
   } catch (err) {
     logger.error(`[Auto-Scan] ❌ Loading analysis failed: ${err}`);


### PR DESCRIPTION
💡 **What**: Replaced redundant `fs.existsSync` checks before `fs.statSync` and `fs.readFileSync` with a `try/catch` block handling the `ENOENT` error.
🎯 **Why**: Checking for existence before a file operation is a Time-Of-Check to Time-Of-Use (TOCTOU) antipattern. It doubles the number of synchronous, blocking system calls to the OS.
📊 **Impact**: Eliminates one system call per file checked on the hot paths `discoverProjects` and `loadAnalysis`, reducing Node.js event loop blocking.
🔬 **Measurement**: Verify with `pnpm build` and `pnpm test`. Also added `.jules/bolt.md` documentation regarding this nuance (explicitly avoiding turning standalone `existsSync` checks into `try { statSync } catch {}` due to exception and allocation overhead).

---
*PR created automatically by Jules for task [5188045071542276693](https://jules.google.com/task/5188045071542276693) started by @giauphan*