### PR TITLE
🎨 Palette: Improve accessibility of dashboard components

### DIFF
--- a/dashboard/src/components/Dashboard.tsx
+++ b/dashboard/src/components/Dashboard.tsx
@@ -535,6 +535,7 @@ export const Dashboard: React.FC = () => {
               <li key={tab} style={{ marginBottom: '1rem' }}>
                 <button
                   onClick={() => setActiveTab(tab)}
+                  aria-current={activeTab === tab ? "page" : undefined}
                   style={{
                     width: '100%', padding: '0.75rem 1rem', borderRadius: '8px',
                     background: activeTab === tab ? 'var(--button-active-background)' : 'transparent',

--- a/dashboard/src/components/DreamMemoryView.tsx
+++ b/dashboard/src/components/DreamMemoryView.tsx
@@ -339,7 +339,7 @@ export function DreamMemoryView() {
         </div>
       </div>
 
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1.5rem', flexWrap: 'wrap' }}>
+      <div role="group" aria-label="Filter memories by type" style={{ display: 'flex', gap: '0.5rem', marginBottom: '1.5rem', flexWrap: 'wrap' }}>
         {['KNOWLEDGE', 'PREFERENCE', 'MISTAKE', 'PATTERN'].map(type => (
           <button
             key={type}

--- a/dashboard/src/components/KnowledgeGraphView.tsx
+++ b/dashboard/src/components/KnowledgeGraphView.tsx
@@ -129,7 +129,7 @@ export const KnowledgeGraphView: React.FC<KnowledgeGraphViewProps> = ({
         </div>
 
         {/* Filter chips */}
-        <div style={{ position: 'absolute', top: '1.5rem', right: '1.5rem', zIndex: 10, display: 'flex', gap: '0.5rem' }}>
+        <div role="group" aria-label="Filter entities by type" style={{ position: 'absolute', top: '1.5rem', right: '1.5rem', zIndex: 10, display: 'flex', gap: '0.5rem' }}>
           {filters.map(f => (
             <button
               type="button"


### PR DESCRIPTION
### 💡 What: 
Added proper accessibility markup (`aria-current` for navigation, `role="group"` and `aria-label` for filter controls) to multiple dashboard components.

### 🎯 Why: 
Screen reader users need to be able to identify which page they are currently on in the navigation, and they need context when navigating arrays of functionally grouped elements like toggle buttons and filters.

### 📸 Before/After:
*Visuals unchanged, purely semantic additions for assistive tech.*
*(Verified locally via Playwright screenshots)*

### ♿ Accessibility:
- Added `aria-current="page"` to the active tab button in `Dashboard.tsx`.
- Wrapped memory type filter buttons in `DreamMemoryView.tsx` with a `role="group"` and `aria-label`.
- Wrapped entity type filter buttons in `KnowledgeGraphView.tsx` with a `role="group"` and `aria-label`.

---
*PR created automatically by Jules for task [4548853994829656512](https://jules.google.com/task/4548853994829656512) started by @giauphan*