### PR TITLE
🎨 Palette: [UX improvement] Add proper ARIA attributes to navigation and filter groups

### DIFF
--- a/dashboard/src/components/Dashboard.tsx
+++ b/dashboard/src/components/Dashboard.tsx
@@ -535,6 +535,7 @@ export const Dashboard: React.FC = () => {
               <li key={tab} style={{ marginBottom: '1rem' }}>
                 <button
                   onClick={() => setActiveTab(tab)}
+                  aria-current={activeTab === tab ? "page" : undefined}
                   style={{
                     width: '100%', padding: '0.75rem 1rem', borderRadius: '8px',
                     background: activeTab === tab ? 'var(--button-active-background)' : 'transparent',

--- a/dashboard/src/components/DreamMemoryView.tsx
+++ b/dashboard/src/components/DreamMemoryView.tsx
@@ -339,7 +339,7 @@ export function DreamMemoryView() {
         </div>
       </div>
 
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1.5rem', flexWrap: 'wrap' }}>
+      <div role="group" aria-label="Filter memories by type" style={{ display: 'flex', gap: '0.5rem', marginBottom: '1.5rem', flexWrap: 'wrap' }}>
         {['KNOWLEDGE', 'PREFERENCE', 'MISTAKE', 'PATTERN'].map(type => (
           <button
             key={type}

--- a/dashboard/src/components/KnowledgeGraphView.tsx
+++ b/dashboard/src/components/KnowledgeGraphView.tsx
@@ -129,7 +129,7 @@ export const KnowledgeGraphView: React.FC<KnowledgeGraphViewProps> = ({
         </div>
 
         {/* Filter chips */}
-        <div style={{ position: 'absolute', top: '1.5rem', right: '1.5rem', zIndex: 10, display: 'flex', gap: '0.5rem' }}>
+        <div role="group" aria-label="Filter graph by entity type" style={{ position: 'absolute', top: '1.5rem', right: '1.5rem', zIndex: 10, display: 'flex', gap: '0.5rem' }}>
           {filters.map(f => (
             <button
               type="button"


### PR DESCRIPTION
💡 What: Added `aria-current="page"` to the active dashboard navigation tab and wrapped related filter buttons in Knowledge Graph and Dream Memories with `role="group"` and `aria-label`.
🎯 Why: Groups related filter buttons together so screen readers provide better context to visually impaired users, and correctly announces the active navigation tab.
📸 Before/After: Visuals remained identical. See attached screenshot in verification step.
♿ Accessibility: Improved screen reader support for navigation and filtering components by explicitly linking them.

---
*PR created automatically by Jules for task [8018596886158316505](https://jules.google.com/task/8018596886158316505) started by @giauphan*