### PR TITLE
🎨 Palette: Add focus-visible classes to interactive elements

### DIFF
--- a/dashboard/src/components/CloudIndexView.tsx
+++ b/dashboard/src/components/CloudIndexView.tsx
@@ -58,6 +58,7 @@ export const CloudIndexView: React.FC<CloudIndexViewProps> = ({
                 aria-checked={isIndexingEnabled}
                 aria-label="Enable Codebase Indexing"
                 disabled={isUpdatingSettings}
+                className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
                 style={{
                   width: '24px', height: '24px', border: '2px solid var(--primary-neon)', borderRadius: '6px',
                   display: 'flex', alignItems: 'center', justifyContent: 'center',

--- a/dashboard/src/components/ControlCenterView.tsx
+++ b/dashboard/src/components/ControlCenterView.tsx
@@ -142,10 +142,10 @@ const freqLabels: Record<string, string> = {
                         </div>
                       </div>
                       <div style={{ display: 'flex', gap: '0.5rem' }}>
-                        <button aria-label="Copy token" title="Copy token" onClick={() => copyToClipboard(key.key, key.id)} className="btn-ghost" style={{ padding: '0.5rem' }}>
+                        <button aria-label="Copy token" title="Copy token" onClick={() => copyToClipboard(key.key, key.id)} className="btn-ghost focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]" style={{ padding: '0.5rem' }}>
                           {copiedId === key.id ? <Check size={16} color="#00F0FF" /> : <Copy size={16} />}
                         </button>
-                        <button aria-label="Delete token" title="Delete token" onClick={() => deleteKey(key.id)} className="btn-ghost" style={{ padding: '0.5rem', color: '#FF4B4B' }}>
+                        <button aria-label="Delete token" title="Delete token" onClick={() => deleteKey(key.id)} className="btn-ghost focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]" style={{ padding: '0.5rem', color: '#FF4B4B' }}>
                           <Trash2 size={16} />
                         </button>
                       </div>
@@ -191,6 +191,7 @@ const freqLabels: Record<string, string> = {
                 <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
                   <label id="cron-enabled-label" style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>Enabled</label>
                   <button role="switch" aria-checked={cronEnabled} aria-labelledby="cron-enabled-label" onClick={() => setCronEnabled(!cronEnabled)}
+                    className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
                     style={{
                       width: '44px', height: '24px', borderRadius: '12px', border: 'none', cursor: 'pointer',
                       background: cronEnabled ? 'var(--primary-neon)' : 'rgba(255,255,255,0.2)',

--- a/dashboard/src/components/KnowledgeGraphView.tsx
+++ b/dashboard/src/components/KnowledgeGraphView.tsx
@@ -156,6 +156,7 @@ export const KnowledgeGraphView: React.FC<KnowledgeGraphViewProps> = ({
             onClick={() => setIsFullscreen(!isFullscreen)}
             aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
             title={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+            className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
             style={{
               padding: '0.5rem', borderRadius: '8px', border: '1px solid rgba(255,255,255,0.15)',
               background: 'rgba(0,0,0,0.7)', color: '#fff', cursor: 'pointer',


### PR DESCRIPTION
💡 What: Added focus-visible classes to interactive elements in ControlCenterView, CloudIndexView, and KnowledgeGraphView.
🎯 Why: Improves keyboard navigation visibility by providing clear focus rings, as custom interactive elements built with inline styles frequently lack default browser focus indicators.
♿ Accessibility: Enhances accessibility for users relying on keyboard navigation by providing a clear visual indication of the focused element.

---
*PR created automatically by Jules for task [914202862535664679](https://jules.google.com/task/914202862535664679) started by @giauphan*