### PR TITLE
⚡ Bolt: Accelerate CodeAtlas project discovery through chunked async scanning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ CODEATLAS_MCP_PORT=3382
 # CORS allowlist (comma-separated origins)
 ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000
 
+# Project Scanning Concurrency (Optional: max parallel directory reads, defaults to 50)
+CODEATLAS_PROJECT_SCAN_CHUNK_SIZE=50
+
 # ── Multi-Tenant ─────────────────────────────────────────
 CODEATLAS_MULTI_TENANT=false
 CODEATLAS_PROJECTS_ROOT=./tenants

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -388,8 +388,8 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
     let chunkSize = 50;
     if (process.env.CODEATLAS_PROJECT_SCAN_CHUNK_SIZE) {
       const parsed = parseInt(process.env.CODEATLAS_PROJECT_SCAN_CHUNK_SIZE, 10);
-      if (!isNaN(parsed) && parsed > 0) {
-        chunkSize = Math.max(1, Math.min(parsed, entries.length > 0 ? entries.length : 50));
+      if (!isNaN(parsed) && parsed >= 1) {
+        chunkSize = parsed;
       }
     }
 
@@ -398,6 +398,7 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
         if (entry.isDirectory() && entry.name !== "node_modules" && !entry.name.startsWith(".")) {
           const subPath = path.join(parentDir, entry.name);
           if (await fileExists(path.join(subPath, ".codeatlas"))) {
+            // Array.push is synchronous and atomic on the JS main thread; safe from race conditions here
             discovered.push(path.resolve(subPath));
           } else {
             // Check 2nd level
@@ -411,10 +412,14 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
                   }
                 }
               }));
-            } catch { /* skip */ }
+            } catch (err) {
+              logger.debug(`[Project-Discovery] Skipped sub-directory read for ${subPath}: ${err}`);
+            }
           }
         }
-      } catch { /* skip */ }
+      } catch (err) {
+        logger.debug(`[Project-Discovery] Skipped processing entry ${entry.name}: ${err}`);
+      }
     };
 
     // We keep outer chunking in case the limit mechanism is not p-limit, to give basic throttling

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -13,6 +13,11 @@ export interface AnalysisResultLocal extends AnalysisResult {
   stats?: { files: number; functions: number; classes: number; dependencies: number; circularDeps: number; deadCode: number };
 }
 
+/** Helper to format error messages robustly */
+function extractErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 /** Unified stats helper */
 export function getStats(analysis: AnalysisResultLocal) {
   const ec = analysis.entityCounts;
@@ -414,14 +419,12 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
                 }
               }));
             } catch (err) {
-              const msg = err instanceof Error ? err.message : String(err);
-              logger.debug(`[Project-Discovery] Skipped sub-directory read for ${subPath}: ${msg}`);
+              logger.debug(`[Project-Discovery] Skipped sub-directory read for ${subPath}: ${extractErrorMessage(err)}`);
             }
           }
         }
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        logger.debug(`[Project-Discovery] Skipped processing entry ${entry.name}: ${msg}`);
+        logger.debug(`[Project-Discovery] Skipped processing entry ${entry.name}: ${extractErrorMessage(err)}`);
       }
     };
 

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -420,26 +420,17 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
             try {
               const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
 
-              // Map child entries as detached limit() jobs directly into Promise.all.
-              // We intentionally do NOT `await` the inner Promise.all from within `processDirEntry`.
-              // This is crucial: if a parent job holds its concurrency slot and waits for inner jobs
-              // that cannot acquire slots (because the queue is full of other parents), it deadlocks.
-              // Returning the Promise array directly to the caller flattens the hierarchy in the event loop.
-              return Promise.all(
-                subEntries.map(subEntry => limit(async () => {
-                  try {
-                    if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
-                      const subSubPath = path.join(subPath, subEntry.name);
-                      if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
-                        discovered.push(path.resolve(subSubPath));
-                      }
-                    }
-                  } catch {
-                    // Swallow deep file system errors to preserve fail-skip semantics
+              // We `await` the inner `Promise.all` here, which holds the current concurrency slot.
+              // This is safe from deadlocks because the inner jobs themselves do NOT use the limiter queue.
+              // They execute immediately within the bounds of the outer chunk's open concurrency limit.
+              await Promise.all(subEntries.map(async (subEntry) => {
+                if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
+                  const subSubPath = path.join(subPath, subEntry.name);
+                  if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
+                    discovered.push(path.resolve(subSubPath));
                   }
-                }))
-              ).then(() => {}); // Coerce to Promise<void> signature
-
+                }
+              }));
             } catch (err) {
               const msg = err instanceof Error ? err.message : String(err);
               if (msg.includes('EACCES') || msg.includes('ENOENT')) return;

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -432,16 +432,16 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
                 }
               }));
             } catch (err) {
-              const msg = err instanceof Error ? err.message : String(err);
+              const msg = extractErrorMessage(err);
               if (msg.includes('EACCES') || msg.includes('ENOENT')) return;
-              logger.debug(`[Project-Discovery] Skipped sub-directory read for ${subPath}: ${extractErrorMessage(err)}`);
+              logger.warn(`[Project-Discovery] ⚠️ Skipped sub-directory read for ${subPath}: ${msg}`);
             }
           }
         }
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
+        const msg = extractErrorMessage(err);
         if (msg.includes('EACCES') || msg.includes('ENOENT')) return;
-        logger.debug(`[Project-Discovery] Skipped processing entry ${entry.name}: ${extractErrorMessage(err)}`);
+        logger.warn(`[Project-Discovery] ⚠️ Skipped processing entry ${entry.name}: ${msg}`);
       }
     };
 

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -370,8 +370,7 @@ export function scanForCodeatlasProjects(parentDir: string): string[] {
 
 /**
  * Scans a directory 2-levels deep to discover '.codeatlas' projects.
- * Uses a manual chunked concurrency strategy to avoid EMFILE limits
- * and OOM during deep tree traversal on heavy monorepos.
+ * Uses a manual chunked concurrency strategy to avoid EMFILE limits.
  */
 export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<string[]> {
   const discovered: string[] = [];
@@ -407,8 +406,6 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
       }
     }
 
-    // Process directory entries via chunks to naturally limit outer concurrency
-    // and avoid EMFILE without requiring external dependencies or nested deadlock risks.
     const processDirEntry = async (entry: fs.Dirent, currentParentDir: string, currentDiscovered: string[]): Promise<void> => {
       try {
         const isDir = entry.isDirectory() && entry.name !== "node_modules" && !entry.name.startsWith(".");
@@ -420,8 +417,6 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
             // Check 2nd level
             try {
               const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
-              // We chunk the sub entries exactly like the outer loop to strictly bound deeply nested directories
-              // and prevent massive Promise.all spikes that could exhaust OS resources on massive repos.
               for (let j = 0; j < subEntries.length; j += concurrencyLimit) {
                 const subChunk = subEntries.slice(j, j + concurrencyLimit);
                 await Promise.all(subChunk.map(async (subEntry) => {
@@ -435,17 +430,13 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
               }
             } catch (err: any) {
               if (err && (err.code === 'EACCES' || err.code === 'ENOENT')) return;
-              const msg = extractErrorMessage(err);
-              if (msg.includes('EACCES') || msg.includes('ENOENT')) return;
-              logger.warn(`[Project-Discovery] ⚠️ Skipped sub-directory read for ${subPath}: ${msg}`);
+              logger.warn(`[Project-Discovery] ⚠️ Skipped sub-directory read for ${subPath}: ${extractErrorMessage(err)}`);
             }
           }
         }
       } catch (err: any) {
         if (err && (err.code === 'EACCES' || err.code === 'ENOENT')) return;
-        const msg = extractErrorMessage(err);
-        if (msg.includes('EACCES') || msg.includes('ENOENT')) return;
-        logger.warn(`[Project-Discovery] ⚠️ Skipped processing entry ${entry.name}: ${msg}`);
+        logger.warn(`[Project-Discovery] ⚠️ Skipped processing entry ${entry.name}: ${extractErrorMessage(err)}`);
       }
     };
 

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -370,7 +370,7 @@ export function scanForCodeatlasProjects(parentDir: string): string[] {
 
 /**
  * Scans a directory 2-levels deep to discover '.codeatlas' projects.
- * Uses a strict bounded concurrency strategy via `p-limit` to avoid EMFILE limits
+ * Uses a manual chunked concurrency strategy to avoid EMFILE limits
  * and OOM during deep tree traversal on heavy monorepos.
  */
 export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<string[]> {
@@ -395,8 +395,11 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
     }
     
     const entries = await fs.promises.readdir(parentDir, { withFileTypes: true });
-    let concurrencyLimit = 50;
+
+    const DEFAULT_CONCURRENCY_LIMIT = 50;
     const MAX_CONCURRENCY_CAP = 1000;
+
+    let concurrencyLimit = DEFAULT_CONCURRENCY_LIMIT;
     if (process.env.CODEATLAS_PROJECT_SCAN_CHUNK_SIZE) {
       const parsed = Number.parseInt(process.env.CODEATLAS_PROJECT_SCAN_CHUNK_SIZE, 10);
       if (!Number.isNaN(parsed) && parsed >= 1) {
@@ -430,14 +433,16 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
                   }
                 }));
               }
-            } catch (err) {
+            } catch (err: any) {
+              if (err && (err.code === 'EACCES' || err.code === 'ENOENT')) return;
               const msg = extractErrorMessage(err);
               if (msg.includes('EACCES') || msg.includes('ENOENT')) return;
               logger.warn(`[Project-Discovery] ⚠️ Skipped sub-directory read for ${subPath}: ${msg}`);
             }
           }
         }
-      } catch (err) {
+      } catch (err: any) {
+        if (err && (err.code === 'EACCES' || err.code === 'ENOENT')) return;
         const msg = extractErrorMessage(err);
         if (msg.includes('EACCES') || msg.includes('ENOENT')) return;
         logger.warn(`[Project-Discovery] ⚠️ Skipped processing entry ${entry.name}: ${msg}`);

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -18,6 +18,15 @@ function extractErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+/** Helper to check if an error is a recoverable/expected filesystem error */
+function isRecoverableError(err: unknown): boolean {
+  if (err instanceof Error && ('code' in err)) {
+    const code = (err as any).code;
+    return code === 'EACCES' || code === 'ENOENT';
+  }
+  return false;
+}
+
 /** Unified stats helper */
 export function getStats(analysis: AnalysisResultLocal) {
   const ec = analysis.entityCounts;
@@ -430,17 +439,26 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
                 }));
               }
             } catch (err: unknown) {
-              if (err instanceof Error && ('code' in err) && (err as any).code && ((err as any).code === 'EACCES' || (err as any).code === 'ENOENT')) return;
+              if (isRecoverableError(err)) {
+                logger.debug(`[Project-Discovery] 🛡️ Ignored inaccessible sub-directory: ${subPath}`);
+                return;
+              }
               logger.warn(`[Project-Discovery] ⚠️ Skipped sub-directory read for ${subPath}: ${extractErrorMessage(err)}`);
             }
           }
         }
       } catch (err: unknown) {
-        if (err instanceof Error && ('code' in err) && (err as any).code && ((err as any).code === 'EACCES' || (err as any).code === 'ENOENT')) return;
+        if (isRecoverableError(err)) {
+          logger.debug(`[Project-Discovery] 🛡️ Ignored inaccessible directory entry: ${entry.name}`);
+          return;
+        }
         logger.warn(`[Project-Discovery] ⚠️ Skipped processing entry ${entry.name}: ${extractErrorMessage(err)}`);
       }
     };
 
+    // To prevent quadratic concurrency blowup (where each outer limit launches multiple inner loops
+    // bounded by the same limit), the inner loop inherits the same batch size but does NOT use an overarching limit.
+    // This allows natural Promise.all bursting bounded cleanly per-directory.
     for (let i = 0; i < entries.length; i += concurrencyLimit) {
       const chunk = entries.slice(i, i + concurrencyLimit);
       await Promise.all(chunk.map(entry => processDirEntry(entry, parentDir, discovered)));

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -385,6 +385,7 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
     }
     
     const entries = await fs.promises.readdir(parentDir, { withFileTypes: true });
+    // TODO: Consider making chunkSize configurable via env var for users on unusual systems with lower FD limits
     const chunkSize = 50; // Batch concurrency to avoid EMFILE limits while speeding up scans
 
     for (let i = 0; i < entries.length; i += chunkSize) {

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -418,56 +418,56 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
       }
     }
 
-    // A single global limit tightly caps total concurrent async file system checks across
-    // all branches of the traversal, preventing multiplicative concurrency bursts.
-    const limit = pLimit(concurrencyLimit);
-
-    const checkSecondLevel = async (subPath: string, currentDiscovered: string[]): Promise<void> => {
-      try {
-        const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
-        // Map tasks safely within the global limit queue rather than isolated Promise chunks
-        await Promise.all(subEntries.map(subEntry => limit(async () => {
-          if (isScanableDirectory(subEntry)) {
-            const subSubPath = path.join(subPath, subEntry.name);
-            if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
-              currentDiscovered.push(path.resolve(subSubPath));
-            }
-          }
-        })));
-      } catch (err: unknown) {
-        if (isRecoverableError(err)) {
-          logger.debug(`[Project-Discovery] ⚠️ Ignored inaccessible sub-directory: ${subPath}`);
-          return;
-        }
-        logger.warn(`[Project-Discovery] ⚠️ Skipped sub-directory read for ${subPath}: ${extractErrorMessage(err)}`);
-      }
-    };
-
+    // Process directory entries sequentially via chunks to naturally limit concurrency
+    // and avoid EMFILE without requiring external dependencies or nested deadlock risks.
     const processDirEntry = async (entry: fs.Dirent, currentParentDir: string, currentDiscovered: string[]): Promise<void> => {
       try {
-        if (!isScanableDirectory(entry)) return;
-
-        const subPath = path.join(currentParentDir, entry.name);
-        if (await fileExists(path.join(subPath, ".codeatlas"))) {
-          currentDiscovered.push(path.resolve(subPath));
-        } else {
-          // Detach the sub-directory scan from the global limit queue here.
-          // `checkSecondLevel` itself pushes operations back into the `limit` queue cleanly,
-          // but we cannot `await` it inside a function that is already consuming a `limit` slot,
-          // otherwise it would cause a circular-wait deadlock when the queue is saturated.
-          return checkSecondLevel(subPath, currentDiscovered);
+        if (isScanableDirectory(entry)) {
+          const subPath = path.join(currentParentDir, entry.name);
+          if (await fileExists(path.join(subPath, ".codeatlas"))) {
+            currentDiscovered.push(path.resolve(subPath));
+          } else {
+            // Check 2nd level
+            try {
+              const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
+              // We chunk the sub entries exactly like the outer loop to strictly bound deeply nested directories
+              // and prevent massive Promise.all spikes that could exhaust OS resources on massive repos.
+              for (let j = 0; j < subEntries.length; j += concurrencyLimit) {
+                const subChunk = subEntries.slice(j, j + concurrencyLimit);
+                await Promise.all(subChunk.map(async (subEntry) => {
+                  if (isScanableDirectory(subEntry)) {
+                    const subSubPath = path.join(subPath, subEntry.name);
+                    if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
+                      currentDiscovered.push(path.resolve(subSubPath));
+                    }
+                  }
+                }));
+              }
+            } catch (err: unknown) {
+              if (isRecoverableError(err)) {
+                logger.debug(`[Project-Discovery] 🛡️ Ignored inaccessible sub-directory: ${subPath}`);
+                return;
+              }
+              logger.warn(`[Project-Discovery] ⚠️ Skipped sub-directory read for ${subPath}: ${extractErrorMessage(err)}`);
+            }
+          }
         }
       } catch (err: unknown) {
         if (isRecoverableError(err)) {
-          logger.debug(`[Project-Discovery] ⚠️ Ignored inaccessible directory entry: ${entry.name}`);
+          logger.debug(`[Project-Discovery] 🛡️ Ignored inaccessible directory entry: ${entry.name}`);
           return;
         }
         logger.warn(`[Project-Discovery] ⚠️ Skipped processing entry ${entry.name}: ${extractErrorMessage(err)}`);
       }
     };
 
-    // The mapping executes instantly but defers the actual work correctly to the p-limit queue
-    await Promise.all(entries.map(entry => limit(() => processDirEntry(entry, parentDir, discovered))));
+    // To prevent quadratic concurrency blowup (where each outer limit launches multiple inner loops
+    // bounded by the same limit), the inner loop inherits the same batch size but does NOT use an overarching limit.
+    // This allows natural Promise.all bursting bounded cleanly per-directory.
+    for (let i = 0; i < entries.length; i += concurrencyLimit) {
+      const chunk = entries.slice(i, i + concurrencyLimit);
+      await Promise.all(chunk.map(entry => processDirEntry(entry, parentDir, discovered)));
+    }
   } catch (err) {
     logger.error(`[Project-Discovery] ❌ Failed to read parent directory during scan: ${extractErrorMessage(err)}`);
   }

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -416,38 +416,8 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
       }
     }
 
-    // A simple utility to chunk arrays and process them concurrently
-    const processInChunks = async <T>(items: T[], chunkSize: number, processor: (item: T) => Promise<void>) => {
-      for (let i = 0; i < items.length; i += chunkSize) {
-        const chunk = items.slice(i, i + chunkSize);
-        await Promise.all(chunk.map(processor));
-      }
-    };
-
     // Process directory entries sequentially via chunks to naturally limit concurrency
     // and avoid EMFILE without requiring external dependencies or nested deadlock risks.
-    const checkSecondLevel = async (subPath: string, currentDiscovered: string[]): Promise<void> => {
-      try {
-        const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
-        // We chunk the sub entries exactly like the outer loop to strictly bound deeply nested directories
-        // and prevent massive Promise.all spikes that could exhaust OS resources on massive repos.
-        await processInChunks(subEntries, concurrencyLimit, async (subEntry) => {
-          if (isScanableDirectory(subEntry)) {
-            const subSubPath = path.join(subPath, subEntry.name);
-            if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
-              currentDiscovered.push(path.resolve(subSubPath));
-            }
-          }
-        });
-      } catch (err: unknown) {
-        if (isRecoverableError(err)) {
-          logger.debug(`[Project-Discovery] 🛡️ Ignored inaccessible sub-directory: ${subPath}`);
-          return;
-        }
-        logger.warn(`[Project-Discovery] ⚠️ Skipped sub-directory read for ${subPath}: ${extractErrorMessage(err)}`);
-      }
-    };
-
     const processDirEntry = async (entry: fs.Dirent, currentParentDir: string, currentDiscovered: string[]): Promise<void> => {
       try {
         if (!isScanableDirectory(entry)) return;
@@ -456,7 +426,29 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
         if (await fileExists(path.join(subPath, ".codeatlas"))) {
           currentDiscovered.push(path.resolve(subPath));
         } else {
-          await checkSecondLevel(subPath, currentDiscovered);
+          // checkSecondLevel inlined
+          try {
+            const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
+            // We chunk the sub entries to strictly bound deeply nested directories
+            // and prevent massive Promise.all spikes that could exhaust OS resources on massive repos.
+            for (let i = 0; i < subEntries.length; i += concurrencyLimit) {
+              const chunk = subEntries.slice(i, i + concurrencyLimit);
+              await Promise.all(chunk.map(async (subEntry) => {
+                if (isScanableDirectory(subEntry)) {
+                  const subSubPath = path.join(subPath, subEntry.name);
+                  if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
+                    currentDiscovered.push(path.resolve(subSubPath));
+                  }
+                }
+              }));
+            }
+          } catch (err: unknown) {
+            if (isRecoverableError(err)) {
+              logger.debug(`[Project-Discovery] 🛡️ Ignored inaccessible sub-directory: ${subPath}`);
+              return;
+            }
+            logger.warn(`[Project-Discovery] ⚠️ Skipped sub-directory read for ${subPath}: ${extractErrorMessage(err)}`);
+          }
         }
       } catch (err: unknown) {
         if (isRecoverableError(err)) {
@@ -467,7 +459,10 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
       }
     };
 
-    await processInChunks(entries, concurrencyLimit, entry => processDirEntry(entry, parentDir, discovered));
+    for (let i = 0; i < entries.length; i += concurrencyLimit) {
+      const chunk = entries.slice(i, i + concurrencyLimit);
+      await Promise.all(chunk.map(entry => processDirEntry(entry, parentDir, discovered)));
+    }
   } catch (err) {
     logger.error(`[Project-Discovery] ❌ Failed to read parent directory during scan: ${extractErrorMessage(err)}`);
   }

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -8,7 +8,6 @@ import { AnalysisResult } from "../types/index.js";
 import { authStorage } from "../utils/context.js";
 import { logger } from "../utils/logger.js";
 import { indexingService } from "./indexingService.js";
-import pLimit from "p-limit";
 
 export interface AnalysisResultLocal extends AnalysisResult {
   stats?: { files: number; functions: number; classes: number; dependencies: number; circularDeps: number; deadCode: number };
@@ -418,6 +417,14 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
       }
     }
 
+    // A simple utility to chunk arrays and process them concurrently
+    const processInChunks = async <T>(items: T[], chunkSize: number, processor: (item: T) => Promise<void>) => {
+      for (let i = 0; i < items.length; i += chunkSize) {
+        const chunk = items.slice(i, i + chunkSize);
+        await Promise.all(chunk.map(processor));
+      }
+    };
+
     // Process directory entries sequentially via chunks to naturally limit concurrency
     // and avoid EMFILE without requiring external dependencies or nested deadlock risks.
     const processDirEntry = async (entry: fs.Dirent, currentParentDir: string, currentDiscovered: string[]): Promise<void> => {
@@ -432,17 +439,14 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
               const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
               // We chunk the sub entries exactly like the outer loop to strictly bound deeply nested directories
               // and prevent massive Promise.all spikes that could exhaust OS resources on massive repos.
-              for (let j = 0; j < subEntries.length; j += concurrencyLimit) {
-                const subChunk = subEntries.slice(j, j + concurrencyLimit);
-                await Promise.all(subChunk.map(async (subEntry) => {
-                  if (isScanableDirectory(subEntry)) {
-                    const subSubPath = path.join(subPath, subEntry.name);
-                    if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
-                      currentDiscovered.push(path.resolve(subSubPath));
-                    }
+              await processInChunks(subEntries, concurrencyLimit, async (subEntry) => {
+                if (isScanableDirectory(subEntry)) {
+                  const subSubPath = path.join(subPath, subEntry.name);
+                  if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
+                    currentDiscovered.push(path.resolve(subSubPath));
                   }
-                }));
-              }
+                }
+              });
             } catch (err: unknown) {
               if (isRecoverableError(err)) {
                 logger.debug(`[Project-Discovery] 🛡️ Ignored inaccessible sub-directory: ${subPath}`);
@@ -461,13 +465,7 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
       }
     };
 
-    // To prevent quadratic concurrency blowup (where each outer limit launches multiple inner loops
-    // bounded by the same limit), the inner loop inherits the same batch size but does NOT use an overarching limit.
-    // This allows natural Promise.all bursting bounded cleanly per-directory.
-    for (let i = 0; i < entries.length; i += concurrencyLimit) {
-      const chunk = entries.slice(i, i + concurrencyLimit);
-      await Promise.all(chunk.map(entry => processDirEntry(entry, parentDir, discovered)));
-    }
+    await processInChunks(entries, concurrencyLimit, entry => processDirEntry(entry, parentDir, discovered));
   } catch (err) {
     logger.error(`[Project-Discovery] ❌ Failed to read parent directory during scan: ${extractErrorMessage(err)}`);
   }

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -8,7 +8,6 @@ import { AnalysisResult } from "../types/index.js";
 import { authStorage } from "../utils/context.js";
 import { logger } from "../utils/logger.js";
 import { indexingService } from "./indexingService.js";
-import pLimit from "p-limit";
 
 export interface AnalysisResultLocal extends AnalysisResult {
   stats?: { files: number; functions: number; classes: number; dependencies: number; circularDeps: number; deadCode: number };
@@ -405,29 +404,24 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
       }
     }
 
-    // A single global limit strictly bounds filesystem checks across all nested directory layers
-    const limit = pLimit(concurrencyLimit);
-
-    const processDirEntry = async (entry: fs.Dirent): Promise<void> => {
+    // Process directory entries sequentially via chunks to naturally limit concurrency
+    // and avoid EMFILE without requiring external dependencies or nested deadlock risks.
+    const processDirEntry = async (entry: fs.Dirent, currentParentDir: string, currentDiscovered: string[]): Promise<void> => {
       try {
         const isDir = entry.isDirectory() && entry.name !== "node_modules" && !entry.name.startsWith(".");
         if (isDir) {
-          const subPath = path.join(parentDir, entry.name);
+          const subPath = path.join(currentParentDir, entry.name);
           if (await fileExists(path.join(subPath, ".codeatlas"))) {
-            discovered.push(path.resolve(subPath));
+            currentDiscovered.push(path.resolve(subPath));
           } else {
             // Check 2nd level
             try {
               const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
-
-              // We `await` the inner `Promise.all` here, which holds the current concurrency slot.
-              // This is safe from deadlocks because the inner jobs themselves do NOT use the limiter queue.
-              // They execute immediately within the bounds of the outer chunk's open concurrency limit.
               await Promise.all(subEntries.map(async (subEntry) => {
                 if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
                   const subSubPath = path.join(subPath, subEntry.name);
                   if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
-                    discovered.push(path.resolve(subSubPath));
+                    currentDiscovered.push(path.resolve(subSubPath));
                   }
                 }
               }));
@@ -445,7 +439,10 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
       }
     };
 
-    await Promise.all(entries.map(entry => limit(() => processDirEntry(entry))));
+    for (let i = 0; i < entries.length; i += concurrencyLimit) {
+      const chunk = entries.slice(i, i + concurrencyLimit);
+      await Promise.all(chunk.map(entry => processDirEntry(entry, parentDir, discovered)));
+    }
   } catch (err) {
     logger.error(`[Project-Discovery] ❌ Failed to scan for .codeatlas projects: ${extractErrorMessage(err)}`);
   }

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -389,7 +389,8 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
     if (process.env.CODEATLAS_PROJECT_SCAN_CHUNK_SIZE) {
       const parsed = parseInt(process.env.CODEATLAS_PROJECT_SCAN_CHUNK_SIZE, 10);
       if (!isNaN(parsed) && parsed >= 1) {
-        chunkSize = parsed;
+        // Cap at 1000 to prevent accidental OS limit exhaustion from typo'd massive values
+        chunkSize = Math.min(parsed, 1000);
       }
     }
 
@@ -413,16 +414,18 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
                 }
               }));
             } catch (err) {
-              logger.debug(`[Project-Discovery] Skipped sub-directory read for ${subPath}: ${err}`);
+              const msg = err instanceof Error ? err.message : String(err);
+              logger.debug(`[Project-Discovery] Skipped sub-directory read for ${subPath}: ${msg}`);
             }
           }
         }
       } catch (err) {
-        logger.debug(`[Project-Discovery] Skipped processing entry ${entry.name}: ${err}`);
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.debug(`[Project-Discovery] Skipped processing entry ${entry.name}: ${msg}`);
       }
     };
 
-    // We keep outer chunking in case the limit mechanism is not p-limit, to give basic throttling
+    // Process directories in batched chunks to limit concurrent file system operations
     for (let i = 0; i < entries.length; i += chunkSize) {
       const chunk = entries.slice(i, i + chunkSize);
       await Promise.all(chunk.map(processDirEntry));

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -387,34 +387,36 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
     const entries = await fs.promises.readdir(parentDir, { withFileTypes: true });
     const chunkSize = process.env.CODEATLAS_PROJECT_SCAN_CHUNK_SIZE ? parseInt(process.env.CODEATLAS_PROJECT_SCAN_CHUNK_SIZE, 10) : 50;
 
+    const processDirEntry = async (entry: fs.Dirent) => {
+      try {
+        if (entry.isDirectory() && entry.name !== "node_modules" && !entry.name.startsWith(".")) {
+          const subPath = path.join(parentDir, entry.name);
+          if (await fileExists(path.join(subPath, ".codeatlas"))) {
+            discovered.push(path.resolve(subPath));
+          } else {
+            // Check 2nd level
+            try {
+              const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
+              for (let j = 0; j < subEntries.length; j += chunkSize) {
+                const subChunk = subEntries.slice(j, j + chunkSize);
+                await Promise.all(subChunk.map(async (subEntry) => {
+                  if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
+                    const subSubPath = path.join(subPath, subEntry.name);
+                    if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
+                      discovered.push(path.resolve(subSubPath));
+                    }
+                  }
+                }));
+              }
+            } catch { /* skip */ }
+          }
+        }
+      } catch { /* skip */ }
+    };
+
     for (let i = 0; i < entries.length; i += chunkSize) {
       const chunk = entries.slice(i, i + chunkSize);
-      await Promise.all(chunk.map(async (entry) => {
-        try {
-          if (entry.isDirectory() && entry.name !== "node_modules" && !entry.name.startsWith(".")) {
-            const subPath = path.join(parentDir, entry.name);
-            if (await fileExists(path.join(subPath, ".codeatlas"))) {
-              discovered.push(path.resolve(subPath));
-            } else {
-              // Check 2nd level
-              try {
-                const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
-                for (let j = 0; j < subEntries.length; j += chunkSize) {
-                  const subChunk = subEntries.slice(j, j + chunkSize);
-                  await Promise.all(subChunk.map(async (subEntry) => {
-                    if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
-                      const subSubPath = path.join(subPath, subEntry.name);
-                      if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
-                        discovered.push(path.resolve(subSubPath));
-                      }
-                    }
-                  }));
-                }
-              } catch { /* skip */ }
-            }
-          }
-        } catch { /* skip */ }
-      }));
+      await Promise.all(chunk.map(processDirEntry));
     }
   } catch (err) {
     logger.error(`[Project-Discovery] ❌ Failed to scan for .codeatlas projects: ${err}`);

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -385,29 +385,37 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
     }
     
     const entries = await fs.promises.readdir(parentDir, { withFileTypes: true });
-    for (const entry of entries) {
-      if (entry.isDirectory() && entry.name !== "node_modules" && !entry.name.startsWith(".")) {
-        const subPath = path.join(parentDir, entry.name);
-        if (await fileExists(path.join(subPath, ".codeatlas"))) {
-          discovered.push(path.resolve(subPath));
-        } else {
-          // Check 2nd level
-          try {
-            const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
-            for (const subEntry of subEntries) {
-              if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
-                const subSubPath = path.join(subPath, subEntry.name);
-                if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
-                  discovered.push(path.resolve(subSubPath));
-                }
+    const chunkSize = 50; // Batch concurrency to avoid EMFILE limits while speeding up scans
+
+    for (let i = 0; i < entries.length; i += chunkSize) {
+      const chunk = entries.slice(i, i + chunkSize);
+      await Promise.all(chunk.map(async (entry) => {
+        if (entry.isDirectory() && entry.name !== "node_modules" && !entry.name.startsWith(".")) {
+          const subPath = path.join(parentDir, entry.name);
+          if (await fileExists(path.join(subPath, ".codeatlas"))) {
+            discovered.push(path.resolve(subPath));
+          } else {
+            // Check 2nd level
+            try {
+              const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
+              for (let j = 0; j < subEntries.length; j += chunkSize) {
+                const subChunk = subEntries.slice(j, j + chunkSize);
+                await Promise.all(subChunk.map(async (subEntry) => {
+                  if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
+                    const subSubPath = path.join(subPath, subEntry.name);
+                    if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
+                      discovered.push(path.resolve(subSubPath));
+                    }
+                  }
+                }));
               }
-            }
-          } catch { /* skip */ }
+            } catch { /* skip */ }
+          }
         }
-      }
+      }));
     }
   } catch (err) {
-    logger.error(`[Project-Discovery] ❌ Failed async scan for .codeatlas projects: ${err}`);
+    logger.error(`[Project-Discovery] ❌ Failed to scan for .codeatlas projects: ${err}`);
   }
   return discovered;
 }

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -391,28 +391,32 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
     for (let i = 0; i < entries.length; i += chunkSize) {
       const chunk = entries.slice(i, i + chunkSize);
       await Promise.all(chunk.map(async (entry) => {
-        if (entry.isDirectory() && entry.name !== "node_modules" && !entry.name.startsWith(".")) {
-          const subPath = path.join(parentDir, entry.name);
-          if (await fileExists(path.join(subPath, ".codeatlas"))) {
-            discovered.push(path.resolve(subPath));
-          } else {
-            // Check 2nd level
-            try {
-              const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
-              for (let j = 0; j < subEntries.length; j += chunkSize) {
-                const subChunk = subEntries.slice(j, j + chunkSize);
-                await Promise.all(subChunk.map(async (subEntry) => {
-                  if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
-                    const subSubPath = path.join(subPath, subEntry.name);
-                    if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
-                      discovered.push(path.resolve(subSubPath));
-                    }
-                  }
-                }));
-              }
-            } catch { /* skip */ }
+        try {
+          if (entry.isDirectory() && entry.name !== "node_modules" && !entry.name.startsWith(".")) {
+            const subPath = path.join(parentDir, entry.name);
+            if (await fileExists(path.join(subPath, ".codeatlas"))) {
+              discovered.push(path.resolve(subPath));
+            } else {
+              // Check 2nd level
+              try {
+                const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
+                for (let j = 0; j < subEntries.length; j += chunkSize) {
+                  const subChunk = subEntries.slice(j, j + chunkSize);
+                  await Promise.all(subChunk.map(async (subEntry) => {
+                    try {
+                      if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
+                        const subSubPath = path.join(subPath, subEntry.name);
+                        if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
+                          discovered.push(path.resolve(subSubPath));
+                        }
+                      }
+                    } catch { /* skip */ }
+                  }));
+                }
+              } catch { /* skip */ }
+            }
           }
-        }
+        } catch { /* skip */ }
       }));
     }
   } catch (err) {

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -385,8 +385,7 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
     }
     
     const entries = await fs.promises.readdir(parentDir, { withFileTypes: true });
-    // TODO: Consider making chunkSize configurable via env var for users on unusual systems with lower FD limits
-    const chunkSize = 50; // Batch concurrency to avoid EMFILE limits while speeding up scans
+    const chunkSize = process.env.CODEATLAS_PROJECT_SCAN_CHUNK_SIZE ? parseInt(process.env.CODEATLAS_PROJECT_SCAN_CHUNK_SIZE, 10) : 50;
 
     for (let i = 0; i < entries.length; i += chunkSize) {
       const chunk = entries.slice(i, i + chunkSize);
@@ -403,14 +402,12 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
                 for (let j = 0; j < subEntries.length; j += chunkSize) {
                   const subChunk = subEntries.slice(j, j + chunkSize);
                   await Promise.all(subChunk.map(async (subEntry) => {
-                    try {
-                      if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
-                        const subSubPath = path.join(subPath, subEntry.name);
-                        if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
-                          discovered.push(path.resolve(subSubPath));
-                        }
+                    if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
+                      const subSubPath = path.join(subPath, subEntry.name);
+                      if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
+                        discovered.push(path.resolve(subSubPath));
                       }
-                    } catch { /* skip */ }
+                    }
                   }));
                 }
               } catch { /* skip */ }

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -8,6 +8,7 @@ import { AnalysisResult } from "../types/index.js";
 import { authStorage } from "../utils/context.js";
 import { logger } from "../utils/logger.js";
 import { indexingService } from "./indexingService.js";
+import pLimit from "p-limit";
 
 export interface AnalysisResultLocal extends AnalysisResult {
   stats?: { files: number; functions: number; classes: number; dependencies: number; circularDeps: number; deadCode: number };
@@ -376,7 +377,8 @@ export function scanForCodeatlasProjects(parentDir: string): string[] {
 
 /**
  * Scans a directory 2-levels deep to discover '.codeatlas' projects.
- * Uses a manual chunked concurrency strategy to avoid EMFILE limits.
+ * Uses a strict bounded concurrency strategy via `p-limit` to prevent EMFILE and OS resource
+ * exhaustion during deep tree traversals on massive monorepos, preventing multiplicative bursts.
  */
 const isScanableDirectory = (entry: fs.Dirent) => entry.isDirectory() && entry.name !== "node_modules" && !entry.name.startsWith(".");
 
@@ -403,7 +405,7 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
     
     const entries = await fs.promises.readdir(parentDir, { withFileTypes: true });
 
-    /** Default chunks of parallel ops per sweep to avoid EMFILE limits */
+    /** Default limits for parallel fs checks */
     const DEFAULT_CONCURRENCY_LIMIT = 50;
     /** Safe max ceiling on concurrency to protect OS resources against misconfiguration */
     const MAX_CONCURRENCY_CAP = 1000;
@@ -416,20 +418,22 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
       }
     }
 
+    // A single global limit tightly caps total concurrent async file system checks across
+    // all branches of the traversal, preventing multiplicative concurrency bursts.
+    const limit = pLimit(concurrencyLimit);
+
     const checkSecondLevel = async (subPath: string, currentDiscovered: string[]): Promise<void> => {
       try {
         const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
-        for (let j = 0; j < subEntries.length; j += concurrencyLimit) {
-          const subChunk = subEntries.slice(j, j + concurrencyLimit);
-          await Promise.all(subChunk.map(async (subEntry) => {
-            if (isScanableDirectory(subEntry)) {
-              const subSubPath = path.join(subPath, subEntry.name);
-              if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
-                currentDiscovered.push(path.resolve(subSubPath));
-              }
+        // Map tasks safely within the global limit queue rather than isolated Promise chunks
+        await Promise.all(subEntries.map(subEntry => limit(async () => {
+          if (isScanableDirectory(subEntry)) {
+            const subSubPath = path.join(subPath, subEntry.name);
+            if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
+              currentDiscovered.push(path.resolve(subSubPath));
             }
-          }));
-        }
+          }
+        })));
       } catch (err: unknown) {
         if (isRecoverableError(err)) {
           logger.debug(`[Project-Discovery] ⚠️ Ignored inaccessible sub-directory: ${subPath}`);
@@ -447,7 +451,11 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
         if (await fileExists(path.join(subPath, ".codeatlas"))) {
           currentDiscovered.push(path.resolve(subPath));
         } else {
-          await checkSecondLevel(subPath, currentDiscovered);
+          // Detach the sub-directory scan from the global limit queue here.
+          // `checkSecondLevel` itself pushes operations back into the `limit` queue cleanly,
+          // but we cannot `await` it inside a function that is already consuming a `limit` slot,
+          // otherwise it would cause a circular-wait deadlock when the queue is saturated.
+          return checkSecondLevel(subPath, currentDiscovered);
         }
       } catch (err: unknown) {
         if (isRecoverableError(err)) {
@@ -458,13 +466,8 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
       }
     };
 
-    // To prevent quadratic concurrency blowup (where each outer limit launches multiple inner loops
-    // bounded by the same limit), the inner loop inherits the same batch size but does NOT use an overarching limit.
-    // This allows natural Promise.all bursting bounded cleanly per-directory.
-    for (let i = 0; i < entries.length; i += concurrencyLimit) {
-      const chunk = entries.slice(i, i + concurrencyLimit);
-      await Promise.all(chunk.map(entry => processDirEntry(entry, parentDir, discovered)));
-    }
+    // The mapping executes instantly but defers the actual work correctly to the p-limit queue
+    await Promise.all(entries.map(entry => limit(() => processDirEntry(entry, parentDir, discovered))));
   } catch (err) {
     logger.error(`[Project-Discovery] ❌ Failed to read parent directory during scan: ${extractErrorMessage(err)}`);
   }

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -376,8 +376,7 @@ export function scanForCodeatlasProjects(parentDir: string): string[] {
 
 /**
  * Scans a directory 2-levels deep to discover '.codeatlas' projects.
- * Uses a strict bounded concurrency strategy via `p-limit` to prevent EMFILE and OS resource
- * exhaustion during deep tree traversals on massive monorepos, preventing multiplicative bursts.
+ * Uses a manual chunked concurrency strategy to avoid EMFILE limits.
  */
 const isScanableDirectory = (entry: fs.Dirent) => entry.isDirectory() && entry.name !== "node_modules" && !entry.name.startsWith(".");
 
@@ -427,34 +426,37 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
 
     // Process directory entries sequentially via chunks to naturally limit concurrency
     // and avoid EMFILE without requiring external dependencies or nested deadlock risks.
-    const processDirEntry = async (entry: fs.Dirent, currentParentDir: string, currentDiscovered: string[]): Promise<void> => {
+    const checkSecondLevel = async (subPath: string, currentDiscovered: string[]): Promise<void> => {
       try {
-        if (isScanableDirectory(entry)) {
-          const subPath = path.join(currentParentDir, entry.name);
-          if (await fileExists(path.join(subPath, ".codeatlas"))) {
-            currentDiscovered.push(path.resolve(subPath));
-          } else {
-            // Check 2nd level
-            try {
-              const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
-              // We chunk the sub entries exactly like the outer loop to strictly bound deeply nested directories
-              // and prevent massive Promise.all spikes that could exhaust OS resources on massive repos.
-              await processInChunks(subEntries, concurrencyLimit, async (subEntry) => {
-                if (isScanableDirectory(subEntry)) {
-                  const subSubPath = path.join(subPath, subEntry.name);
-                  if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
-                    currentDiscovered.push(path.resolve(subSubPath));
-                  }
-                }
-              });
-            } catch (err: unknown) {
-              if (isRecoverableError(err)) {
-                logger.debug(`[Project-Discovery] 🛡️ Ignored inaccessible sub-directory: ${subPath}`);
-                return;
-              }
-              logger.warn(`[Project-Discovery] ⚠️ Skipped sub-directory read for ${subPath}: ${extractErrorMessage(err)}`);
+        const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
+        // We chunk the sub entries exactly like the outer loop to strictly bound deeply nested directories
+        // and prevent massive Promise.all spikes that could exhaust OS resources on massive repos.
+        await processInChunks(subEntries, concurrencyLimit, async (subEntry) => {
+          if (isScanableDirectory(subEntry)) {
+            const subSubPath = path.join(subPath, subEntry.name);
+            if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
+              currentDiscovered.push(path.resolve(subSubPath));
             }
           }
+        });
+      } catch (err: unknown) {
+        if (isRecoverableError(err)) {
+          logger.debug(`[Project-Discovery] 🛡️ Ignored inaccessible sub-directory: ${subPath}`);
+          return;
+        }
+        logger.warn(`[Project-Discovery] ⚠️ Skipped sub-directory read for ${subPath}: ${extractErrorMessage(err)}`);
+      }
+    };
+
+    const processDirEntry = async (entry: fs.Dirent, currentParentDir: string, currentDiscovered: string[]): Promise<void> => {
+      try {
+        if (!isScanableDirectory(entry)) return;
+
+        const subPath = path.join(currentParentDir, entry.name);
+        if (await fileExists(path.join(subPath, ".codeatlas"))) {
+          currentDiscovered.push(path.resolve(subPath));
+        } else {
+          await checkSecondLevel(subPath, currentDiscovered);
         }
       } catch (err: unknown) {
         if (isRecoverableError(err)) {

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -369,6 +369,11 @@ export function scanForCodeatlasProjects(parentDir: string): string[] {
   return discovered;
 }
 
+/**
+ * Scans a directory 2-levels deep to discover '.codeatlas' projects.
+ * Uses a bounded concurrency strategy mapping across sibling folders via chunking to avoid EMFILE limits
+ * and OOM, without nesting promises that could cause execution deadlocks on dense graphs.
+ */
 export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<string[]> {
   const discovered: string[] = [];
   try {
@@ -392,11 +397,11 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
     
     const entries = await fs.promises.readdir(parentDir, { withFileTypes: true });
     let concurrencyLimit = 50;
+    const MAX_CONCURRENCY_CAP = 1000;
     if (process.env.CODEATLAS_PROJECT_SCAN_CHUNK_SIZE) {
       const parsed = Number.parseInt(process.env.CODEATLAS_PROJECT_SCAN_CHUNK_SIZE, 10);
       if (!Number.isNaN(parsed) && parsed >= 1) {
-        // Cap at 1000 to prevent accidental OS limit exhaustion from typo'd massive values
-        concurrencyLimit = Math.min(parsed, 1000);
+        concurrencyLimit = Math.min(parsed, MAX_CONCURRENCY_CAP);
       }
     }
 
@@ -408,22 +413,24 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
         if (isDir) {
           const subPath = path.join(parentDir, entry.name);
           if (await fileExists(path.join(subPath, ".codeatlas"))) {
-            // Array.push is synchronous and atomic on the JS main thread; safe from race conditions here
             discovered.push(path.resolve(subPath));
           } else {
             // Check 2nd level
             try {
               const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
-              // Remove inner limit() wrapper to avoid shared-limiter deadlock and unexpected bottlenecking,
-              // relying entirely on the outer loop to throttle parent directories.
-              await Promise.all(subEntries.map(async (subEntry) => {
-                if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
-                  const subSubPath = path.join(subPath, subEntry.name);
-                  if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
-                    discovered.push(path.resolve(subSubPath));
+              // We chunk the sub entries to ensure dense folders with >1000 inner entries
+              // do not spike `Promise.all` concurrency limits, adhering to `concurrencyLimit`.
+              for (let j = 0; j < subEntries.length; j += concurrencyLimit) {
+                const subChunk = subEntries.slice(j, j + concurrencyLimit);
+                await Promise.all(subChunk.map(async (subEntry) => {
+                  if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
+                    const subSubPath = path.join(subPath, subEntry.name);
+                    if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
+                      discovered.push(path.resolve(subSubPath));
+                    }
                   }
-                }
-              }));
+                }));
+              }
             } catch (err) {
               logger.debug(`[Project-Discovery] Skipped sub-directory read for ${subPath}: ${extractErrorMessage(err)}`);
             }

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -8,6 +8,7 @@ import { AnalysisResult } from "../types/index.js";
 import { authStorage } from "../utils/context.js";
 import { logger } from "../utils/logger.js";
 import { indexingService } from "./indexingService.js";
+import pLimit from "p-limit";
 
 export interface AnalysisResultLocal extends AnalysisResult {
   stats?: { files: number; functions: number; classes: number; dependencies: number; circularDeps: number; deadCode: number };
@@ -390,18 +391,21 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
     }
     
     const entries = await fs.promises.readdir(parentDir, { withFileTypes: true });
-    let chunkSize = 50;
+    let concurrencyLimit = 50;
     if (process.env.CODEATLAS_PROJECT_SCAN_CHUNK_SIZE) {
-      const parsed = parseInt(process.env.CODEATLAS_PROJECT_SCAN_CHUNK_SIZE, 10);
-      if (!isNaN(parsed) && parsed >= 1) {
+      const parsed = Number.parseInt(process.env.CODEATLAS_PROJECT_SCAN_CHUNK_SIZE, 10);
+      if (!Number.isNaN(parsed) && parsed >= 1) {
         // Cap at 1000 to prevent accidental OS limit exhaustion from typo'd massive values
-        chunkSize = Math.min(parsed, 1000);
+        concurrencyLimit = Math.min(parsed, 1000);
       }
     }
 
+    const limit = pLimit(concurrencyLimit);
+
     const processDirEntry = async (entry: fs.Dirent) => {
       try {
-        if (entry.isDirectory() && entry.name !== "node_modules" && !entry.name.startsWith(".")) {
+        const isDir = entry.isDirectory() && entry.name !== "node_modules" && !entry.name.startsWith(".");
+        if (isDir) {
           const subPath = path.join(parentDir, entry.name);
           if (await fileExists(path.join(subPath, ".codeatlas"))) {
             // Array.push is synchronous and atomic on the JS main thread; safe from race conditions here
@@ -410,14 +414,14 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
             // Check 2nd level
             try {
               const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
-              await Promise.all(subEntries.map(async (subEntry) => {
+              await Promise.all(subEntries.map(subEntry => limit(async () => {
                 if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
                   const subSubPath = path.join(subPath, subEntry.name);
                   if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
                     discovered.push(path.resolve(subSubPath));
                   }
                 }
-              }));
+              })));
             } catch (err) {
               logger.debug(`[Project-Discovery] Skipped sub-directory read for ${subPath}: ${extractErrorMessage(err)}`);
             }
@@ -428,11 +432,8 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
       }
     };
 
-    // Process directories in batched chunks to limit concurrent file system operations
-    for (let i = 0; i < entries.length; i += chunkSize) {
-      const chunk = entries.slice(i, i + chunkSize);
-      await Promise.all(chunk.map(processDirEntry));
-    }
+    // Use p-limit to globally throttle concurrent filesystem operations across all levels
+    await Promise.all(entries.map(entry => limit(() => processDirEntry(entry))));
   } catch (err) {
     logger.error(`[Project-Discovery] ❌ Failed to scan for .codeatlas projects: ${err}`);
   }

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -8,7 +8,6 @@ import { AnalysisResult } from "../types/index.js";
 import { authStorage } from "../utils/context.js";
 import { logger } from "../utils/logger.js";
 import { indexingService } from "./indexingService.js";
-import pLimit from "p-limit";
 
 export interface AnalysisResultLocal extends AnalysisResult {
   stats?: { files: number; functions: number; classes: number; dependencies: number; circularDeps: number; deadCode: number };
@@ -364,7 +363,7 @@ export function scanForCodeatlasProjects(parentDir: string): string[] {
       }
     }
   } catch (err) {
-    logger.error(`[Project-Discovery] ❌ Failed to scan for .codeatlas projects: ${err}`);
+    logger.error(`[Project-Discovery] ❌ Failed to scan for .codeatlas projects: ${extractErrorMessage(err)}`);
   }
   return discovered;
 }
@@ -404,8 +403,6 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
         concurrencyLimit = Math.min(parsed, MAX_CONCURRENCY_CAP);
       }
     }
-
-    const limit = pLimit(concurrencyLimit);
 
     const processDirEntry = async (entry: fs.Dirent) => {
       try {
@@ -448,7 +445,7 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
       await Promise.all(chunk.map(processDirEntry));
     }
   } catch (err) {
-    logger.error(`[Project-Discovery] ❌ Failed to scan for .codeatlas projects: ${err}`);
+    logger.error(`[Project-Discovery] ❌ Failed to scan for .codeatlas projects: ${extractErrorMessage(err)}`);
   }
   return discovered;
 }

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -372,6 +372,8 @@ export function scanForCodeatlasProjects(parentDir: string): string[] {
  * Scans a directory 2-levels deep to discover '.codeatlas' projects.
  * Uses a manual chunked concurrency strategy to avoid EMFILE limits.
  */
+const isScanableDirectory = (entry: fs.Dirent) => entry.isDirectory() && entry.name !== "node_modules" && !entry.name.startsWith(".");
+
 export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<string[]> {
   const discovered: string[] = [];
   try {
@@ -408,8 +410,7 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
 
     const processDirEntry = async (entry: fs.Dirent, currentParentDir: string, currentDiscovered: string[]): Promise<void> => {
       try {
-        const isDir = entry.isDirectory() && entry.name !== "node_modules" && !entry.name.startsWith(".");
-        if (isDir) {
+        if (isScanableDirectory(entry)) {
           const subPath = path.join(currentParentDir, entry.name);
           if (await fileExists(path.join(subPath, ".codeatlas"))) {
             currentDiscovered.push(path.resolve(subPath));
@@ -420,7 +421,7 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
               for (let j = 0; j < subEntries.length; j += concurrencyLimit) {
                 const subChunk = subEntries.slice(j, j + concurrencyLimit);
                 await Promise.all(subChunk.map(async (subEntry) => {
-                  if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
+                  if (isScanableDirectory(subEntry)) {
                     const subSubPath = path.join(subPath, subEntry.name);
                     if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
                       currentDiscovered.push(path.resolve(subSubPath));
@@ -428,14 +429,14 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
                   }
                 }));
               }
-            } catch (err: any) {
-              if (err && (err.code === 'EACCES' || err.code === 'ENOENT')) return;
+            } catch (err: unknown) {
+              if (err instanceof Error && ('code' in err) && (err as any).code && ((err as any).code === 'EACCES' || (err as any).code === 'ENOENT')) return;
               logger.warn(`[Project-Discovery] ⚠️ Skipped sub-directory read for ${subPath}: ${extractErrorMessage(err)}`);
             }
           }
         }
-      } catch (err: any) {
-        if (err && (err.code === 'EACCES' || err.code === 'ENOENT')) return;
+      } catch (err: unknown) {
+        if (err instanceof Error && ('code' in err) && (err as any).code && ((err as any).code === 'EACCES' || (err as any).code === 'ENOENT')) return;
         logger.warn(`[Project-Discovery] ⚠️ Skipped processing entry ${entry.name}: ${extractErrorMessage(err)}`);
       }
     };
@@ -445,7 +446,7 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
       await Promise.all(chunk.map(entry => processDirEntry(entry, parentDir, discovered)));
     }
   } catch (err) {
-    logger.error(`[Project-Discovery] ❌ Failed to scan for .codeatlas projects: ${extractErrorMessage(err)}`);
+    logger.error(`[Project-Discovery] ❌ Failed to read parent directory during scan: ${extractErrorMessage(err)}`);
   }
   return discovered;
 }

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -385,7 +385,13 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
     }
     
     const entries = await fs.promises.readdir(parentDir, { withFileTypes: true });
-    const chunkSize = process.env.CODEATLAS_PROJECT_SCAN_CHUNK_SIZE ? parseInt(process.env.CODEATLAS_PROJECT_SCAN_CHUNK_SIZE, 10) : 50;
+    let chunkSize = 50;
+    if (process.env.CODEATLAS_PROJECT_SCAN_CHUNK_SIZE) {
+      const parsed = parseInt(process.env.CODEATLAS_PROJECT_SCAN_CHUNK_SIZE, 10);
+      if (!isNaN(parsed) && parsed > 0) {
+        chunkSize = Math.max(1, Math.min(parsed, entries.length > 0 ? entries.length : 50));
+      }
+    }
 
     const processDirEntry = async (entry: fs.Dirent) => {
       try {
@@ -397,23 +403,21 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
             // Check 2nd level
             try {
               const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
-              for (let j = 0; j < subEntries.length; j += chunkSize) {
-                const subChunk = subEntries.slice(j, j + chunkSize);
-                await Promise.all(subChunk.map(async (subEntry) => {
-                  if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
-                    const subSubPath = path.join(subPath, subEntry.name);
-                    if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
-                      discovered.push(path.resolve(subSubPath));
-                    }
+              await Promise.all(subEntries.map(async (subEntry) => {
+                if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
+                  const subSubPath = path.join(subPath, subEntry.name);
+                  if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
+                    discovered.push(path.resolve(subSubPath));
                   }
-                }));
-              }
+                }
+              }));
             } catch { /* skip */ }
           }
         }
       } catch { /* skip */ }
     };
 
+    // We keep outer chunking in case the limit mechanism is not p-limit, to give basic throttling
     for (let i = 0; i < entries.length; i += chunkSize) {
       const chunk = entries.slice(i, i + chunkSize);
       await Promise.all(chunk.map(processDirEntry));

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -20,11 +20,8 @@ function extractErrorMessage(err: unknown): string {
 
 /** Helper to check if an error is a recoverable/expected filesystem error */
 function isRecoverableError(err: unknown): boolean {
-  if (err instanceof Error && ('code' in err)) {
-    const code = (err as any).code;
-    return code === 'EACCES' || code === 'ENOENT';
-  }
-  return false;
+  const code = (err as { code?: string })?.code;
+  return code === 'EACCES' || code === 'ENOENT';
 }
 
 /** Unified stats helper */
@@ -435,7 +432,7 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
         }
       } catch (err: unknown) {
         if (isRecoverableError(err)) {
-          logger.debug(`[Project-Discovery] 🛡️ Ignored inaccessible sub-directory: ${subPath}`);
+          logger.debug(`[Project-Discovery] ⚠️ Ignored inaccessible sub-directory: ${subPath}`);
           return;
         }
         logger.warn(`[Project-Discovery] ⚠️ Skipped sub-directory read for ${subPath}: ${extractErrorMessage(err)}`);
@@ -454,7 +451,7 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
         }
       } catch (err: unknown) {
         if (isRecoverableError(err)) {
-          logger.debug(`[Project-Discovery] 🛡️ Ignored inaccessible directory entry: ${entry.name}`);
+          logger.debug(`[Project-Discovery] ⚠️ Ignored inaccessible directory entry: ${entry.name}`);
           return;
         }
         logger.warn(`[Project-Discovery] ⚠️ Skipped processing entry ${entry.name}: ${extractErrorMessage(err)}`);

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -404,7 +404,7 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
       }
     }
 
-    // Process directory entries sequentially via chunks to naturally limit concurrency
+    // Process directory entries via chunks to naturally limit outer concurrency
     // and avoid EMFILE without requiring external dependencies or nested deadlock risks.
     const processDirEntry = async (entry: fs.Dirent, currentParentDir: string, currentDiscovered: string[]): Promise<void> => {
       try {
@@ -417,14 +417,19 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
             // Check 2nd level
             try {
               const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
-              await Promise.all(subEntries.map(async (subEntry) => {
-                if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
-                  const subSubPath = path.join(subPath, subEntry.name);
-                  if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
-                    currentDiscovered.push(path.resolve(subSubPath));
+              // We chunk the sub entries exactly like the outer loop to strictly bound deeply nested directories
+              // and prevent massive Promise.all spikes that could exhaust OS resources on massive repos.
+              for (let j = 0; j < subEntries.length; j += concurrencyLimit) {
+                const subChunk = subEntries.slice(j, j + concurrencyLimit);
+                await Promise.all(subChunk.map(async (subEntry) => {
+                  if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
+                    const subSubPath = path.join(subPath, subEntry.name);
+                    if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
+                      currentDiscovered.push(path.resolve(subSubPath));
+                    }
                   }
-                }
-              }));
+                }));
+              }
             } catch (err) {
               const msg = extractErrorMessage(err);
               if (msg.includes('EACCES') || msg.includes('ENOENT')) return;

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -414,14 +414,16 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
             // Check 2nd level
             try {
               const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
-              await Promise.all(subEntries.map(subEntry => limit(async () => {
+              // Remove inner limit() wrapper to avoid shared-limiter deadlock and unexpected bottlenecking,
+              // relying entirely on the outer loop to throttle parent directories.
+              await Promise.all(subEntries.map(async (subEntry) => {
                 if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
                   const subSubPath = path.join(subPath, subEntry.name);
                   if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
                     discovered.push(path.resolve(subSubPath));
                   }
                 }
-              })));
+              }));
             } catch (err) {
               logger.debug(`[Project-Discovery] Skipped sub-directory read for ${subPath}: ${extractErrorMessage(err)}`);
             }
@@ -432,8 +434,12 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
       }
     };
 
-    // Use p-limit to globally throttle concurrent filesystem operations across all levels
-    await Promise.all(entries.map(entry => limit(() => processDirEntry(entry))));
+    // Process directories in batched chunks instead of global p-limit to avoid nested deadlocks
+    // and confusing concurrency contention across levels.
+    for (let i = 0; i < entries.length; i += concurrencyLimit) {
+      const chunk = entries.slice(i, i + concurrencyLimit);
+      await Promise.all(chunk.map(processDirEntry));
+    }
   } catch (err) {
     logger.error(`[Project-Discovery] ❌ Failed to scan for .codeatlas projects: ${err}`);
   }

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -8,6 +8,7 @@ import { AnalysisResult } from "../types/index.js";
 import { authStorage } from "../utils/context.js";
 import { logger } from "../utils/logger.js";
 import { indexingService } from "./indexingService.js";
+import pLimit from "p-limit";
 
 export interface AnalysisResultLocal extends AnalysisResult {
   stats?: { files: number; functions: number; classes: number; dependencies: number; circularDeps: number; deadCode: number };
@@ -370,8 +371,8 @@ export function scanForCodeatlasProjects(parentDir: string): string[] {
 
 /**
  * Scans a directory 2-levels deep to discover '.codeatlas' projects.
- * Uses a bounded concurrency strategy mapping across sibling folders via chunking to avoid EMFILE limits
- * and OOM, without nesting promises that could cause execution deadlocks on dense graphs.
+ * Uses a strict bounded concurrency strategy via `p-limit` to avoid EMFILE limits
+ * and OOM during deep tree traversal on heavy monorepos.
  */
 export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<string[]> {
   const discovered: string[] = [];
@@ -404,7 +405,10 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
       }
     }
 
-    const processDirEntry = async (entry: fs.Dirent) => {
+    // A single global limit strictly bounds filesystem checks across all nested directory layers
+    const limit = pLimit(concurrencyLimit);
+
+    const processDirEntry = async (entry: fs.Dirent): Promise<void> => {
       try {
         const isDir = entry.isDirectory() && entry.name !== "node_modules" && !entry.name.startsWith(".");
         if (isDir) {
@@ -415,35 +419,42 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
             // Check 2nd level
             try {
               const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
-              // We chunk the sub entries to ensure dense folders with >1000 inner entries
-              // do not spike `Promise.all` concurrency limits, adhering to `concurrencyLimit`.
-              for (let j = 0; j < subEntries.length; j += concurrencyLimit) {
-                const subChunk = subEntries.slice(j, j + concurrencyLimit);
-                await Promise.all(subChunk.map(async (subEntry) => {
-                  if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
-                    const subSubPath = path.join(subPath, subEntry.name);
-                    if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
-                      discovered.push(path.resolve(subSubPath));
+
+              // Map child entries as detached limit() jobs directly into Promise.all.
+              // We intentionally do NOT `await` the inner Promise.all from within `processDirEntry`.
+              // This is crucial: if a parent job holds its concurrency slot and waits for inner jobs
+              // that cannot acquire slots (because the queue is full of other parents), it deadlocks.
+              // Returning the Promise array directly to the caller flattens the hierarchy in the event loop.
+              return Promise.all(
+                subEntries.map(subEntry => limit(async () => {
+                  try {
+                    if (subEntry.isDirectory() && subEntry.name !== "node_modules" && !subEntry.name.startsWith(".")) {
+                      const subSubPath = path.join(subPath, subEntry.name);
+                      if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
+                        discovered.push(path.resolve(subSubPath));
+                      }
                     }
+                  } catch {
+                    // Swallow deep file system errors to preserve fail-skip semantics
                   }
-                }));
-              }
+                }))
+              ).then(() => {}); // Coerce to Promise<void> signature
+
             } catch (err) {
+              const msg = err instanceof Error ? err.message : String(err);
+              if (msg.includes('EACCES') || msg.includes('ENOENT')) return;
               logger.debug(`[Project-Discovery] Skipped sub-directory read for ${subPath}: ${extractErrorMessage(err)}`);
             }
           }
         }
       } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes('EACCES') || msg.includes('ENOENT')) return;
         logger.debug(`[Project-Discovery] Skipped processing entry ${entry.name}: ${extractErrorMessage(err)}`);
       }
     };
 
-    // Process directories in batched chunks instead of global p-limit to avoid nested deadlocks
-    // and confusing concurrency contention across levels.
-    for (let i = 0; i < entries.length; i += concurrencyLimit) {
-      const chunk = entries.slice(i, i + concurrencyLimit);
-      await Promise.all(chunk.map(processDirEntry));
-    }
+    await Promise.all(entries.map(entry => limit(() => processDirEntry(entry))));
   } catch (err) {
     logger.error(`[Project-Discovery] ❌ Failed to scan for .codeatlas projects: ${extractErrorMessage(err)}`);
   }

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -406,7 +406,9 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
     
     const entries = await fs.promises.readdir(parentDir, { withFileTypes: true });
 
+    /** Default chunks of parallel ops per sweep to avoid EMFILE limits */
     const DEFAULT_CONCURRENCY_LIMIT = 50;
+    /** Safe max ceiling on concurrency to protect OS resources against misconfiguration */
     const MAX_CONCURRENCY_CAP = 1000;
 
     let concurrencyLimit = DEFAULT_CONCURRENCY_LIMIT;
@@ -417,35 +419,38 @@ export async function scanForCodeatlasProjectsAsync(parentDir: string): Promise<
       }
     }
 
+    const checkSecondLevel = async (subPath: string, currentDiscovered: string[]): Promise<void> => {
+      try {
+        const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
+        for (let j = 0; j < subEntries.length; j += concurrencyLimit) {
+          const subChunk = subEntries.slice(j, j + concurrencyLimit);
+          await Promise.all(subChunk.map(async (subEntry) => {
+            if (isScanableDirectory(subEntry)) {
+              const subSubPath = path.join(subPath, subEntry.name);
+              if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
+                currentDiscovered.push(path.resolve(subSubPath));
+              }
+            }
+          }));
+        }
+      } catch (err: unknown) {
+        if (isRecoverableError(err)) {
+          logger.debug(`[Project-Discovery] 🛡️ Ignored inaccessible sub-directory: ${subPath}`);
+          return;
+        }
+        logger.warn(`[Project-Discovery] ⚠️ Skipped sub-directory read for ${subPath}: ${extractErrorMessage(err)}`);
+      }
+    };
+
     const processDirEntry = async (entry: fs.Dirent, currentParentDir: string, currentDiscovered: string[]): Promise<void> => {
       try {
-        if (isScanableDirectory(entry)) {
-          const subPath = path.join(currentParentDir, entry.name);
-          if (await fileExists(path.join(subPath, ".codeatlas"))) {
-            currentDiscovered.push(path.resolve(subPath));
-          } else {
-            // Check 2nd level
-            try {
-              const subEntries = await fs.promises.readdir(subPath, { withFileTypes: true });
-              for (let j = 0; j < subEntries.length; j += concurrencyLimit) {
-                const subChunk = subEntries.slice(j, j + concurrencyLimit);
-                await Promise.all(subChunk.map(async (subEntry) => {
-                  if (isScanableDirectory(subEntry)) {
-                    const subSubPath = path.join(subPath, subEntry.name);
-                    if (await fileExists(path.join(subSubPath, ".codeatlas"))) {
-                      currentDiscovered.push(path.resolve(subSubPath));
-                    }
-                  }
-                }));
-              }
-            } catch (err: unknown) {
-              if (isRecoverableError(err)) {
-                logger.debug(`[Project-Discovery] 🛡️ Ignored inaccessible sub-directory: ${subPath}`);
-                return;
-              }
-              logger.warn(`[Project-Discovery] ⚠️ Skipped sub-directory read for ${subPath}: ${extractErrorMessage(err)}`);
-            }
-          }
+        if (!isScanableDirectory(entry)) return;
+
+        const subPath = path.join(currentParentDir, entry.name);
+        if (await fileExists(path.join(subPath, ".codeatlas"))) {
+          currentDiscovered.push(path.resolve(subPath));
+        } else {
+          await checkSecondLevel(subPath, currentDiscovered);
         }
       } catch (err: unknown) {
         if (isRecoverableError(err)) {


### PR DESCRIPTION
💡 **What**: The sequential `for...of` iteration in `scanForCodeatlasProjectsAsync` has been replaced with a chunked `Promise.all` mapping using a chunk size of 50. 
🎯 **Why**: The previous implementation waited for each `fileExists` and `fs.promises.readdir` system call one by one, creating a massive N+1 performance bottleneck during workspace index discovery in directories with many subfolders. Additionally, the nested chunking safely parallelizes the work without introducing deadlock scenarios common with shared `p-limit` instances.
📊 **Impact**: Massively reduces wall-clock time for project discovery by maximizing concurrent filesystem reads, while staying well within the limits of Node.js open file descriptors.
🔬 **Measurement**: Verify by benchmarking the discovery startup time on a repository containing multiple inner `.codeatlas` project structures. Tests and format checks have passed locally to ensure safety.

---
*PR created automatically by Jules for task [256235403325395954](https://jules.google.com/task/256235403325395954) started by @giauphan*