### PR TITLE
🎨 Palette: [UX improvement] Fix non-spinning loading indicators

### DIFF
--- a/dashboard/src/components/OrchestrationTasksView.tsx
+++ b/dashboard/src/components/OrchestrationTasksView.tsx
@@ -101,7 +101,7 @@ export function OrchestrationTasksView() {
             opacity: loading ? 0.6 : 1,
           }}
         >
-          {loading ? <Loader2 size={18} className="spin" /> : <RefreshCw size={18} />}
+          {loading ? <Loader2 size={18} className="animate-spin" /> : <RefreshCw size={18} />}
           {loading ? 'Refreshing…' : 'Refresh Tasks'}
         </motion.button>
       </div>
@@ -145,7 +145,7 @@ export function OrchestrationTasksView() {
       {/* Loading */}
       {loading && (
         <div style={{ textAlign: 'center', padding: '3rem' }}>
-          <Loader2 size={32} className="spin" style={{ color: 'var(--primary-neon)' }} />
+          <Loader2 size={32} className="animate-spin" style={{ color: 'var(--primary-neon)' }} />
         </div>
       )}
 

--- a/dashboard/src/components/SecondBrainView.tsx
+++ b/dashboard/src/components/SecondBrainView.tsx
@@ -107,7 +107,7 @@ export function SecondBrainView() {
             opacity: consolidating ? 0.6 : 1,
           }}
         >
-          {consolidating ? <Loader2 size={18} className="spin" /> : <RefreshCw size={18} />}
+          {consolidating ? <Loader2 size={18} className="animate-spin" /> : <RefreshCw size={18} />}
           {consolidating ? 'Consolidating…' : 'Run Consolidation'}
         </motion.button>
       </div>
@@ -160,7 +160,7 @@ export function SecondBrainView() {
       {/* Loading */}
       {loading && (
         <div style={{ textAlign: 'center', padding: '3rem' }}>
-          <Loader2 size={32} className="spin" style={{ color: 'var(--primary-neon)' }} />
+          <Loader2 size={32} className="animate-spin" style={{ color: 'var(--primary-neon)' }} />
         </div>
       )}
 


### PR DESCRIPTION
💡 **What**: Replaced the non-existent `spin` CSS class with Tailwind's `animate-spin` on loading indicator icons in `OrchestrationTasksView.tsx` and `SecondBrainView.tsx`.
🎯 **Why**: The loading indicators were static, providing no visual feedback to users during long-running tasks like fetching orchestration tasks or consolidating memories.
📸 **Before/After**: Visually, the `Loader2` icons now correctly rotate while the async operations are in progress.
♿ **Accessibility**: Improves cognitive accessibility by providing clear visual feedback that a background process is ongoing.

---
*PR created automatically by Jules for task [2585871027362816378](https://jules.google.com/task/2585871027362816378) started by @giauphan*