### PR TITLE
🎨 Palette: Add focus visible styles to token action buttons

### DIFF
--- a/dashboard/src/components/ControlCenterView.tsx
+++ b/dashboard/src/components/ControlCenterView.tsx
@@ -142,10 +142,10 @@ const freqLabels: Record<string, string> = {
                         </div>
                       </div>
                       <div style={{ display: 'flex', gap: '0.5rem' }}>
-                        <button aria-label="Copy token" title="Copy token" onClick={() => copyToClipboard(key.key, key.id)} className="btn-ghost" style={{ padding: '0.5rem' }}>
+                        <button aria-label="Copy token" title="Copy token" onClick={() => copyToClipboard(key.key, key.id)} className="btn-ghost focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]" style={{ padding: '0.5rem' }}>
                           {copiedId === key.id ? <Check size={16} color="#00F0FF" /> : <Copy size={16} />}
                         </button>
-                        <button aria-label="Delete token" title="Delete token" onClick={() => deleteKey(key.id)} className="btn-ghost" style={{ padding: '0.5rem', color: '#FF4B4B' }}>
+                        <button aria-label="Delete token" title="Delete token" onClick={() => deleteKey(key.id)} className="btn-ghost focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]" style={{ padding: '0.5rem', color: '#FF4B4B' }}>
                           <Trash2 size={16} />
                         </button>
                       </div>


### PR DESCRIPTION
💡 What: Added explicitly styled Tailwind focus rings (`focus-visible`) to the icon-only copy and delete buttons in the "Active Tokens" section of the Control Center.
🎯 Why: Without focus rings, keyboard-only users cannot easily determine which token action button is currently focused, degrading accessibility.
📸 Before/After: Verified via screenshot locally showing a clear cyan focus ring.
♿ Accessibility: Improves keyboard navigation visibility (WCAG 2.4.7 Focus Visible).

---
*PR created automatically by Jules for task [7923533723058143354](https://jules.google.com/task/7923533723058143354) started by @giauphan*