### PR TITLE
🎨 Palette: Add autoComplete attributes to Auth inputs

### DIFF
--- a/dashboard/src/components/Auth.tsx
+++ b/dashboard/src/components/Auth.tsx
@@ -145,14 +145,14 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
                   <label htmlFor="email" style={{ display: 'block', fontSize: '0.75rem', color: 'var(--text-muted)', marginBottom: '0.75rem', fontWeight: 700 }}>EMAIL ADDRESS</label>
                   <div style={{ position: 'relative' }}>
                     <Mail size={18} style={{ position: 'absolute', left: '1rem', top: '1rem', color: 'var(--primary-neon)' }} />
-                    <input id="email" type="email" style={{ paddingLeft: '3rem' }} className="glass-input" placeholder="name@genrostore.com" value={email} onChange={e => setEmail(e.target.value)} required />
+                    <input id="email" type="email" autoComplete="email" style={{ paddingLeft: '3rem' }} className="glass-input" placeholder="name@genrostore.com" value={email} onChange={e => setEmail(e.target.value)} required />
                   </div>
                 </div>
                 <div>
                   <label htmlFor="password" style={{ display: 'block', fontSize: '0.75rem', color: 'var(--text-muted)', marginBottom: '0.75rem', fontWeight: 700 }}>PASSWORD</label>
                   <div style={{ position: 'relative' }}>
                     <Lock size={18} style={{ position: 'absolute', left: '1rem', top: '1rem', color: 'var(--primary-neon)' }} />
-                    <input id="password" type="password" style={{ paddingLeft: '3rem' }} className="glass-input" placeholder="••••••••" value={password} onChange={e => setPassword(e.target.value)} required />
+                    <input id="password" type="password" autoComplete="current-password" style={{ paddingLeft: '3rem' }} className="glass-input" placeholder="••••••••" value={password} onChange={e => setPassword(e.target.value)} required />
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
### 💡 What
Added `autoComplete="email"` and `autoComplete="current-password"` attributes to the login form inputs in `Auth.tsx`.

### 🎯 Why
This is a small but highly impactful UX improvement. Standardizing authentication inputs allows password managers (like 1Password, Bitwarden, or browser-native vaults) to securely and reliably autofill credentials, saving users time and preventing frustration.

### 📸 Before/After
Before: Password managers frequently fail to detect the specific fields to populate.
After: Browsers explicitly recognize the fields as an email address and a current password for logging in.

### ♿ Accessibility
This improvement significantly aids users who rely on autofill due to motor or cognitive disabilities, conforming to WCAG standards for identifying input purposes.

---
*PR created automatically by Jules for task [12852764120148466857](https://jules.google.com/task/12852764120148466857) started by @giauphan*