### PR TITLE
⚡ Bolt: [performance improvement] Eliminate redundant array allocations during graph node processing

### DIFF
--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -492,7 +492,9 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
       const mermaid = lines.join("\n");
 
       // Single-pass counter
-      let moduleCount = 0, classCount = 0, functionCount = 0;
+      let moduleCount = 0;
+      let classCount = 0;
+      let functionCount = 0;
       for (const n of nodes) {
         const type = n.type;
         if (type === "module") moduleCount++;

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -491,7 +491,7 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
 
       const mermaid = lines.join("\n");
 
-      // ⚡ Bolt: Use a single O(N) pass to count nodes instead of multiple O(N) filter.length chains
+      // PERF: Use a single O(N) pass to count nodes instead of multiple O(N) filter.length chains
       // to avoid redundant linear scans and intermediary array allocations.
       let moduleCount = 0, classCount = 0, functionCount = 0;
       for (const n of nodes) {
@@ -572,7 +572,7 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
         }
       }
 
-      // ⚡ Bolt: Use a single O(N) loop to count module types to eliminate redundant array allocation
+      // PERF: Use a single O(N) loop to count module types to eliminate redundant array allocation
       let moduleCount = 0;
       for (const n of nodes) {
         if (n.type === "module") moduleCount++;

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -27,12 +27,13 @@ import { randomUUID } from "node:crypto";
 import { isToolEnabled } from "../config/env.js";
 import { GraphNode } from "../types/index.js";
 
-function countByType<T extends GraphNode['type']>(nodes: GraphNode[], type: T): number {
-  let count = 0;
+function countByTypes<T extends GraphNode['type']>(nodes: GraphNode[], types: T[]): Record<T, number> {
+  const counts = Object.fromEntries(types.map(t => [t, 0])) as Record<T, number>;
   for (const n of nodes) {
-    if (n.type === type) count++;
+    const type = n.type as T;
+    if (counts[type] !== undefined) counts[type]++;
   }
-  return count;
+  return counts;
 }
 
 /** Auto-register tool metadata for A2A Agent Card AND register handler on executor (Stub) */
@@ -500,6 +501,7 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
 
       const mermaid = lines.join("\n");
 
+      const typeCounts = countByTypes(nodes, ["module", "class", "function"]);
       const result = {
         project: loaded.projectName,
         scope: diagramScope,
@@ -508,7 +510,7 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
         linkCount: links.length,
         truncated: loaded.analysis.graph.nodes.length > max,
         mermaidDiagram: mermaid,
-        summary: `System flow for ${loaded.projectName}: ${countByType(nodes, "module")} modules, ${countByType(nodes, "class")} classes, ${countByType(nodes, "function")} functions connected by ${links.length} relationships.`,
+        summary: `System flow for ${loaded.projectName}: ${typeCounts.module} modules, ${typeCounts.class} classes, ${typeCounts.function} functions connected by ${links.length} relationships.`,
       };
 
       return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
@@ -576,7 +578,7 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
         success: syncSuccess,
         project: loaded.projectName,
         stats: {
-          modules: countByType(nodes, "module"),
+          modules: countByTypes(nodes, ["module"]).module,
           totalEntities: nodes.length,
           totalLinks: links.length,
           businessRuleSaved,

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -27,7 +27,7 @@ import { randomUUID } from "node:crypto";
 import { isToolEnabled } from "../config/env.js";
 import { GraphNode } from "../types/index.js";
 
-function countByType(nodes: GraphNode[], type: GraphNode['type']): number {
+function countByType<T extends GraphNode['type']>(nodes: GraphNode[], type: T): number {
   let count = 0;
   for (const n of nodes) {
     if (n.type === type) count++;

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -494,9 +494,10 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
       // Single-pass counter
       let moduleCount = 0, classCount = 0, functionCount = 0;
       for (const n of nodes) {
-        if (n.type === "module") moduleCount++;
-        else if (n.type === "class") classCount++;
-        else if (n.type === "function") functionCount++;
+        const type = n.type;
+        if (type === "module") moduleCount++;
+        else if (type === "class") classCount++;
+        else if (type === "function") functionCount++;
       }
 
       const result = {

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -27,6 +27,10 @@ import { randomUUID } from "node:crypto";
 import { isToolEnabled } from "../config/env.js";
 import { GraphNode } from "../types/index.js";
 
+/**
+ * Processes an array of GraphNodes in a single pass and returns the counts
+ * for the requested node types as an object indexed by those types.
+ */
 function countByTypes<T extends GraphNode['type']>(nodes: GraphNode[], types: T[]): Record<T, number> {
   const counts = Object.fromEntries(types.map(t => [t, 0])) as Record<T, number>;
   for (const n of nodes) {

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -491,6 +491,15 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
 
       const mermaid = lines.join("\n");
 
+      // ⚡ Bolt: Use a single O(N) pass to count nodes instead of multiple O(N) filter.length chains
+      // to avoid redundant linear scans and intermediary array allocations.
+      let moduleCount = 0, classCount = 0, functionCount = 0;
+      for (const n of nodes) {
+        if (n.type === "module") moduleCount++;
+        else if (n.type === "class") classCount++;
+        else if (n.type === "function") functionCount++;
+      }
+
       const result = {
         project: loaded.projectName,
         scope: diagramScope,
@@ -499,7 +508,7 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
         linkCount: links.length,
         truncated: loaded.analysis.graph.nodes.length > max,
         mermaidDiagram: mermaid,
-        summary: `System flow for ${loaded.projectName}: ${nodes.filter((n) => n.type === "module").length} modules, ${nodes.filter((n) => n.type === "class").length} classes, ${nodes.filter((n) => n.type === "function").length} functions connected by ${links.length} relationships.`,
+        summary: `System flow for ${loaded.projectName}: ${moduleCount} modules, ${classCount} classes, ${functionCount} functions connected by ${links.length} relationships.`,
       };
 
       return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
@@ -563,11 +572,17 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
         }
       }
 
+      // ⚡ Bolt: Use a single O(N) loop to count module types to eliminate redundant array allocation
+      let moduleCount = 0;
+      for (const n of nodes) {
+        if (n.type === "module") moduleCount++;
+      }
+
       const result = {
         success: syncSuccess,
         project: loaded.projectName,
         stats: {
-          modules: nodes.filter((n) => n.type === "module").length,
+          modules: moduleCount,
           totalEntities: nodes.length,
           totalLinks: links.length,
           businessRuleSaved,

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -25,6 +25,15 @@ import { indexingService } from "../services/indexingService.js";
 import { authStorage } from "../utils/context.js";
 import { randomUUID } from "node:crypto";
 import { isToolEnabled } from "../config/env.js";
+import { GraphNode } from "../types/index.js";
+
+function countByType(nodes: GraphNode[], type: GraphNode['type']): number {
+  let count = 0;
+  for (const n of nodes) {
+    if (n.type === type) count++;
+  }
+  return count;
+}
 
 /** Auto-register tool metadata for A2A Agent Card AND register handler on executor (Stub) */
 function a2a(name: string, description: string, params: string[]) {
@@ -491,17 +500,6 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
 
       const mermaid = lines.join("\n");
 
-      // Single-pass counter
-      let moduleCount = 0;
-      let classCount = 0;
-      let functionCount = 0;
-      for (const n of nodes) {
-        const type = n.type;
-        if (type === "module") moduleCount++;
-        else if (type === "class") classCount++;
-        else if (type === "function") functionCount++;
-      }
-
       const result = {
         project: loaded.projectName,
         scope: diagramScope,
@@ -510,7 +508,7 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
         linkCount: links.length,
         truncated: loaded.analysis.graph.nodes.length > max,
         mermaidDiagram: mermaid,
-        summary: `System flow for ${loaded.projectName}: ${moduleCount} modules, ${classCount} classes, ${functionCount} functions connected by ${links.length} relationships.`,
+        summary: `System flow for ${loaded.projectName}: ${countByType(nodes, "module")} modules, ${countByType(nodes, "class")} classes, ${countByType(nodes, "function")} functions connected by ${links.length} relationships.`,
       };
 
       return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
@@ -574,17 +572,11 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
         }
       }
 
-      // Single-pass counter
-      let moduleCount = 0;
-      for (const n of nodes) {
-        if (n.type === "module") moduleCount++;
-      }
-
       const result = {
         success: syncSuccess,
         project: loaded.projectName,
         stats: {
-          modules: moduleCount,
+          modules: countByType(nodes, "module"),
           totalEntities: nodes.length,
           totalLinks: links.length,
           businessRuleSaved,

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -491,8 +491,7 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
 
       const mermaid = lines.join("\n");
 
-      // PERF: Use a single O(N) pass to count nodes instead of multiple O(N) filter.length chains
-      // to avoid redundant linear scans and intermediary array allocations.
+      // Single-pass counter
       let moduleCount = 0, classCount = 0, functionCount = 0;
       for (const n of nodes) {
         if (n.type === "module") moduleCount++;
@@ -572,7 +571,7 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
         }
       }
 
-      // PERF: Use a single O(N) loop to count module types to eliminate redundant array allocation
+      // Single-pass counter
       let moduleCount = 0;
       for (const n of nodes) {
         if (n.type === "module") moduleCount++;


### PR DESCRIPTION
💡 **What:** Replaced chained `.filter(...).length` operations in `src/presentation/mcpTools.ts` (`generate_mermaid_diagram` and `sync_system_memory` tools) with a single, linear O(N) `for` loop that counts node types simultaneously.

🎯 **Why:** The previous code triggered multiple full array iterations and redundant intermediary array allocations just to compute the count of each node type. In a codebase visualization tool handling large project graphs, this causes unnecessary garbage collection pressure and CPU bottlenecks.

📊 **Impact:** Reduces O(N) iterations from 3 to 1 and completely eliminates the intermediate array memory allocations per request.

🔬 **Measurement:** Verify by running the tests via `pnpm test` and ensuring `pnpm build` succeeds. Review the diffs to see the clean iteration approach.

---
*PR created automatically by Jules for task [950445999154506890](https://jules.google.com/task/950445999154506890) started by @giauphan*