### PR TITLE
🛡️ Sentinel: [HIGH] Fix arbitrary origin reflection in CORS wildcard configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -23,3 +23,8 @@
 **Vulnerability:** Weak coverage for detecting hardcoded API keys and common SQL statements.
 **Learning:** The internal `SecurityScanner` relies on hardcoded string matching. It previously missed terms like "apikey", "credential", and SQL commands "select", "insert", "update".
 **Prevention:** Regularly review and update static analysis keyword lists to include modern token patterns and complete sets of risky commands.
+
+## 2024-08-15 - Arbitrary Origin Reflection in CORS Wildcard Configuration
+**Vulnerability:** The CORS configuration in `src/presentation/httpServer.ts` reflected arbitrary origins by returning `true` to the origin callback when a wildcard (`*`) was in the `ALLOWED_ORIGINS` configuration, while simultaneously setting `credentials: true`. This completely circumvents browser restrictions on cross-origin credentialed requests, allowing any external site to make authenticated requests.
+**Learning:** Returning `true` to a CORS origin callback instructs the CORS middleware to echo back the requester's `Origin` header in the `Access-Control-Allow-Origin` response header. When combined with `Access-Control-Allow-Credentials: true`, this creates a severe vulnerability where credentials (like cookies or HTTP auth) are sent and accepted from any origin.
+**Prevention:** When securing CORS configurations in the Express HTTP server against arbitrary origin reflection, return the static string `'*'` instead of boolean `true` when a wildcard origin is configured. This correctly sets `Access-Control-Allow-Origin: *` while allowing the browser to properly enforce credential restrictions (browsers inherently block credentialed requests to a wildcard origin), rather than breaking public non-credentialed APIs by outright rejecting them.

--- a/src/presentation/httpServer.ts
+++ b/src/presentation/httpServer.ts
@@ -178,7 +178,7 @@ app.use(cors({
 
     if (allowedList.includes('*')) {
       // With credentials:true, reflect any valid origin dynamically
-      return callback(null, true);
+      return callback(null, '*');
     }
 
     try {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The CORS configuration in the Express server returned `true` to the origin callback when `ALLOWED_ORIGINS` included a wildcard (`*`). When combined with `credentials: true`, this instructed the CORS middleware to echo back the requester's `Origin` header dynamically, effectively allowing any origin to make authenticated cross-origin requests.
🎯 **Impact:** Malicious sites could potentially read or mutate sensitive user data by exploiting the authenticated user's session in the browser.
🔧 **Fix:** Changed the callback return value for the wildcard case from `true` to `'*'`. This sets `Access-Control-Allow-Origin: *`, which browsers inherently block when `credentials: true` is present, thus preventing credentialed cross-origin requests unless an origin is explicitly allowed.
✅ **Verification:**
1. Ran `pnpm test` and `pnpm build` successfully.
2. Verified that requests from unlisted origins will receive an `Access-Control-Allow-Origin: *` header, which the browser will block if credentials are sent.

---
*PR created automatically by Jules for task [9859560385653575902](https://jules.google.com/task/9859560385653575902) started by @giauphan*