### PR TITLE
🎨 Palette: Add focus-visible styles for keyboard navigation

### DIFF
--- a/dashboard/src/components/CloudIndexView.tsx
+++ b/dashboard/src/components/CloudIndexView.tsx
@@ -9,6 +9,7 @@ import {
   Cpu, 
   Zap
 } from 'lucide-react';
+import { FOCUS_RING_CLASS } from '../lib/constants';
 
 interface CloudIndexViewProps {
   analysis: any;
@@ -58,7 +59,7 @@ export const CloudIndexView: React.FC<CloudIndexViewProps> = ({
                 aria-checked={isIndexingEnabled}
                 aria-label="Enable Codebase Indexing"
                 disabled={isUpdatingSettings}
-                className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
+                className={FOCUS_RING_CLASS}
                 style={{
                   width: '24px', height: '24px', border: '2px solid var(--primary-neon)', borderRadius: '6px',
                   display: 'flex', alignItems: 'center', justifyContent: 'center',
@@ -102,7 +103,7 @@ export const CloudIndexView: React.FC<CloudIndexViewProps> = ({
                 onClick={() => setShowAdvanced(!showAdvanced)}
                 aria-expanded={showAdvanced}
                 aria-controls="advanced-configuration-content"
-                className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
+                className={FOCUS_RING_CLASS}
               >
                 <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', color: '#fff', fontWeight: 700 }}>
                   <motion.div animate={{ rotate: showAdvanced ? 90 : 0 }}>{"> "}</motion.div> Setup Information & Advanced Configuration

--- a/dashboard/src/components/CloudIndexView.tsx
+++ b/dashboard/src/components/CloudIndexView.tsx
@@ -66,7 +66,8 @@ export const CloudIndexView: React.FC<CloudIndexViewProps> = ({
                   cursor: isUpdatingSettings ? 'not-allowed' : 'pointer',
                   opacity: isUpdatingSettings ? 0.6 : 1,
                   background: isIndexingEnabled ? 'var(--primary-neon)' : 'transparent',
-                  padding: 0
+                  padding: 0,
+                  outline: 'none'
                 }}
                 onClick={handleToggleClick}
               >

--- a/dashboard/src/components/CloudIndexView.tsx
+++ b/dashboard/src/components/CloudIndexView.tsx
@@ -58,6 +58,7 @@ export const CloudIndexView: React.FC<CloudIndexViewProps> = ({
                 aria-checked={isIndexingEnabled}
                 aria-label="Enable Codebase Indexing"
                 disabled={isUpdatingSettings}
+                className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
                 style={{
                   width: '24px', height: '24px', border: '2px solid var(--primary-neon)', borderRadius: '6px',
                   display: 'flex', alignItems: 'center', justifyContent: 'center',
@@ -101,7 +102,7 @@ export const CloudIndexView: React.FC<CloudIndexViewProps> = ({
                 onClick={() => setShowAdvanced(!showAdvanced)}
                 aria-expanded={showAdvanced}
                 aria-controls="advanced-configuration-content"
-                className="focus-visible:ring-2 focus-visible:ring-primary-neon focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
               >
                 <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', color: '#fff', fontWeight: 700 }}>
                   <motion.div animate={{ rotate: showAdvanced ? 90 : 0 }}>{"> "}</motion.div> Setup Information & Advanced Configuration

--- a/dashboard/src/components/ControlCenterView.tsx
+++ b/dashboard/src/components/ControlCenterView.tsx
@@ -191,10 +191,11 @@ const freqLabels: Record<string, string> = {
                 <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
                   <label id="cron-enabled-label" style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>Enabled</label>
                   <button role="switch" aria-checked={cronEnabled} aria-labelledby="cron-enabled-label" onClick={() => setCronEnabled(!cronEnabled)}
+                    className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
                     style={{
                       width: '44px', height: '24px', borderRadius: '12px', border: 'none', cursor: 'pointer',
                       background: cronEnabled ? 'var(--primary-neon)' : 'rgba(255,255,255,0.2)',
-                      position: 'relative', transition: '0.2s'
+                      position: 'relative', transition: '0.2s', outline: 'none'
                     }}>
                     <div style={{
                       width: '18px', height: '18px', borderRadius: '50%', background: '#fff',

--- a/dashboard/src/components/ControlCenterView.tsx
+++ b/dashboard/src/components/ControlCenterView.tsx
@@ -12,6 +12,7 @@ import {
   Save
 } from 'lucide-react';
 import { getAuthHeaders } from '../lib/auth';
+import { FOCUS_RING_CLASS } from '../lib/constants';
 
 interface ControlCenterProps {
   stats: { totalRequests: number };
@@ -142,10 +143,10 @@ const freqLabels: Record<string, string> = {
                         </div>
                       </div>
                       <div style={{ display: 'flex', gap: '0.5rem' }}>
-                        <button aria-label="Copy token" title="Copy token" onClick={() => copyToClipboard(key.key, key.id)} className="btn-ghost focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]" style={{ padding: '0.5rem' }}>
+                        <button aria-label="Copy token" title="Copy token" onClick={() => copyToClipboard(key.key, key.id)} className={`btn-ghost ${FOCUS_RING_CLASS}`} style={{ padding: '0.5rem' }}>
                           {copiedId === key.id ? <Check size={16} color="#00F0FF" /> : <Copy size={16} />}
                         </button>
-                        <button aria-label="Delete token" title="Delete token" onClick={() => deleteKey(key.id)} className="btn-ghost focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]" style={{ padding: '0.5rem', color: '#FF4B4B' }}>
+                        <button aria-label="Delete token" title="Delete token" onClick={() => deleteKey(key.id)} className={`btn-ghost ${FOCUS_RING_CLASS}`} style={{ padding: '0.5rem', color: '#FF4B4B' }}>
                           <Trash2 size={16} />
                         </button>
                       </div>
@@ -191,7 +192,7 @@ const freqLabels: Record<string, string> = {
                 <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
                   <label id="cron-enabled-label" style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>Enabled</label>
                   <button role="switch" aria-checked={cronEnabled} aria-labelledby="cron-enabled-label" onClick={() => setCronEnabled(!cronEnabled)}
-                    className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
+                    className={FOCUS_RING_CLASS}
                     style={{
                       width: '44px', height: '24px', borderRadius: '12px', border: 'none', cursor: 'pointer',
                       background: cronEnabled ? 'var(--primary-neon)' : 'rgba(255,255,255,0.2)',

--- a/dashboard/src/components/DreamMemoryView.tsx
+++ b/dashboard/src/components/DreamMemoryView.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { Brain, Search, Trash2, AlertCircle, Loader2, Database, Clock, Settings } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { getAuthHeaders } from '../lib/auth';
+import { FOCUS_RING_CLASS } from '../lib/constants';
 
 interface DreamConfig {
   dreams_schedule: string;
@@ -301,7 +302,7 @@ export function DreamMemoryView() {
           }}
           aria-expanded={showConfig}
           aria-controls="dream-config-panel"
-          className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
+          className={FOCUS_RING_CLASS}
           style={{
             padding: '0.75rem 1.25rem', borderRadius: '12px', border: '1px solid rgba(255,255,255,0.1)',
             background: 'rgba(255,255,255,0.05)', color: '#fff', fontWeight: 700, cursor: 'pointer', outline: 'none'
@@ -355,7 +356,7 @@ export function DreamMemoryView() {
               color: selectedTypes.includes(type) ? typeColors[type] : 'var(--text-muted)',
               outline: 'none'
             }}
-            className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
+            className={FOCUS_RING_CLASS}
           >
             {type}
           </button>

--- a/dashboard/src/components/DreamMemoryView.tsx
+++ b/dashboard/src/components/DreamMemoryView.tsx
@@ -301,9 +301,10 @@ export function DreamMemoryView() {
           }}
           aria-expanded={showConfig}
           aria-controls="dream-config-panel"
+          className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
           style={{
             padding: '0.75rem 1.25rem', borderRadius: '12px', border: '1px solid rgba(255,255,255,0.1)',
-            background: 'rgba(255,255,255,0.05)', color: '#fff', fontWeight: 700, cursor: 'pointer'
+            background: 'rgba(255,255,255,0.05)', color: '#fff', fontWeight: 700, cursor: 'pointer', outline: 'none'
           }}>
           <Settings size={18} style={{ marginRight: '0.5rem' }} /> Config
         </button>
@@ -354,7 +355,7 @@ export function DreamMemoryView() {
               color: selectedTypes.includes(type) ? typeColors[type] : 'var(--text-muted)',
               outline: 'none'
             }}
-            className="focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-50"
+            className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
           >
             {type}
           </button>

--- a/dashboard/src/components/KnowledgeGraphView.tsx
+++ b/dashboard/src/components/KnowledgeGraphView.tsx
@@ -136,6 +136,7 @@ export const KnowledgeGraphView: React.FC<KnowledgeGraphViewProps> = ({
               key={f.id}
               onClick={() => toggleFilter(f.id)}
               aria-pressed={activeFilters.includes(f.id)}
+              className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
               style={{
                 display: 'flex', alignItems: 'center', gap: '0.35rem', padding: '0.4rem 0.8rem',
                 borderRadius: '20px', fontSize: '0.8rem', fontWeight: 600,
@@ -143,6 +144,7 @@ export const KnowledgeGraphView: React.FC<KnowledgeGraphViewProps> = ({
                 border: `1px solid ${activeFilters.includes(f.id) ? f.color : 'transparent'}`,
                 color: activeFilters.includes(f.id) ? f.color : 'var(--text-muted)',
                 transition: 'all 0.2s',
+                outline: 'none'
               }}
             >
               {f.icon} {f.label}
@@ -156,10 +158,12 @@ export const KnowledgeGraphView: React.FC<KnowledgeGraphViewProps> = ({
             onClick={() => setIsFullscreen(!isFullscreen)}
             aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
             title={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+            className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
             style={{
               padding: '0.5rem', borderRadius: '8px', border: '1px solid rgba(255,255,255,0.15)',
               background: 'rgba(0,0,0,0.7)', color: '#fff', cursor: 'pointer',
               display: 'flex', alignItems: 'center', justifyContent: 'center',
+              outline: 'none'
             }}
           >
             {isFullscreen ? <Minimize2 size={18} /> : <Maximize2 size={18} />}

--- a/dashboard/src/components/KnowledgeGraphView.tsx
+++ b/dashboard/src/components/KnowledgeGraphView.tsx
@@ -6,6 +6,7 @@ import {
 } from 'lucide-react';
 import { SphericalKnowledgeGraph } from './KnowledgeNetwork3D';
 import { getAuthHeaders } from '../lib/auth';
+import { FOCUS_RING_CLASS } from '../lib/constants';
 
 interface AnalysisData {
   analysis?: AnalysisData;
@@ -136,7 +137,7 @@ export const KnowledgeGraphView: React.FC<KnowledgeGraphViewProps> = ({
               key={f.id}
               onClick={() => toggleFilter(f.id)}
               aria-pressed={activeFilters.includes(f.id)}
-              className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
+              className={FOCUS_RING_CLASS}
               style={{
                 display: 'flex', alignItems: 'center', gap: '0.35rem', padding: '0.4rem 0.8rem',
                 borderRadius: '20px', fontSize: '0.8rem', fontWeight: 600,
@@ -158,7 +159,7 @@ export const KnowledgeGraphView: React.FC<KnowledgeGraphViewProps> = ({
             onClick={() => setIsFullscreen(!isFullscreen)}
             aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
             title={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
-            className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
+            className={FOCUS_RING_CLASS}
             style={{
               padding: '0.5rem', borderRadius: '8px', border: '1px solid rgba(255,255,255,0.15)',
               background: 'rgba(0,0,0,0.7)', color: '#fff', cursor: 'pointer',

--- a/dashboard/src/components/OrchestrationTasksView.tsx
+++ b/dashboard/src/components/OrchestrationTasksView.tsx
@@ -3,6 +3,7 @@ import { Network, Search, Loader2, AlertCircle, CheckCircle2, CircleDot, GitBran
 import { motion } from 'framer-motion';
 import { getAuthHeaders } from '../lib/auth'; // Reusing auth headers utility
 import type { A2AOrchestrationTask, OrchestrationState } from '../../../src/types/a2a'; // Importing types
+import { FOCUS_RING_CLASS } from '../lib/constants';
 
 export function OrchestrationTasksView() {
   const [tasks, setTasks] = useState<A2AOrchestrationTask[]>([]);
@@ -129,7 +130,7 @@ export function OrchestrationTasksView() {
               key={state}
               onClick={() => setFilterState(state)}
               aria-pressed={filterState === state}
-              className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
+              className={FOCUS_RING_CLASS}
               style={{
                 padding: '0.5rem 1rem', borderRadius: '8px', border: '1px solid rgba(255,255,255,0.1)',
                 background: filterState === state ? 'rgba(0,240,255,0.15)' : 'rgba(0,0,0,0.2)',

--- a/dashboard/src/components/OrchestrationTasksView.tsx
+++ b/dashboard/src/components/OrchestrationTasksView.tsx
@@ -129,11 +129,13 @@ export function OrchestrationTasksView() {
               key={state}
               onClick={() => setFilterState(state)}
               aria-pressed={filterState === state}
+              className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
               style={{
                 padding: '0.5rem 1rem', borderRadius: '8px', border: '1px solid rgba(255,255,255,0.1)',
                 background: filterState === state ? 'rgba(0,240,255,0.15)' : 'rgba(0,0,0,0.2)',
                 color: filterState === state ? 'var(--primary-neon)' : 'var(--text-muted)',
                 cursor: 'pointer', fontWeight: 600, fontSize: '0.85rem', transition: 'all 0.2s',
+                outline: 'none'
               }}
             >
               {state.charAt(0).toUpperCase() + state.slice(1).replace('_', ' ')}

--- a/dashboard/src/components/SecondBrainView.tsx
+++ b/dashboard/src/components/SecondBrainView.tsx
@@ -144,11 +144,13 @@ export function SecondBrainView() {
               key={cat}
               onClick={() => setSelectedCategory(cat)}
               aria-pressed={selectedCategory === cat}
+              className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
               style={{
                 padding: '0.5rem 1rem', borderRadius: '8px', border: '1px solid rgba(255,255,255,0.1)',
                 background: selectedCategory === cat ? 'rgba(0,240,255,0.15)' : 'rgba(0,0,0,0.2)',
                 color: selectedCategory === cat ? 'var(--primary-neon)' : 'var(--text-muted)',
                 cursor: 'pointer', fontWeight: 600, fontSize: '0.85rem', transition: 'all 0.2s',
+                outline: 'none'
               }}
             >
               {cat === 'all' ? 'All' : cat}

--- a/dashboard/src/components/SecondBrainView.tsx
+++ b/dashboard/src/components/SecondBrainView.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Brain, Search, Lightbulb, TrendingUp, Archive, AlertCircle, Loader2, RefreshCw } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { getAuthHeaders } from '../lib/auth';
-
+import { FOCUS_RING_CLASS } from '../lib/constants';
 
 interface Concept {
   id: string;
@@ -144,7 +144,7 @@ export function SecondBrainView() {
               key={cat}
               onClick={() => setSelectedCategory(cat)}
               aria-pressed={selectedCategory === cat}
-              className="focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]"
+              className={FOCUS_RING_CLASS}
               style={{
                 padding: '0.5rem 1rem', borderRadius: '8px', border: '1px solid rgba(255,255,255,0.1)',
                 background: selectedCategory === cat ? 'rgba(0,240,255,0.15)' : 'rgba(0,0,0,0.2)',

--- a/dashboard/src/lib/constants.ts
+++ b/dashboard/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const FOCUS_RING_CLASS = 'focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-dark)]';


### PR DESCRIPTION
💡 **What:** Added `focus-visible:ring-2` and associated styling to custom interactive elements (filter chips, toggle switches, and icon buttons) across multiple dashboard views (`CloudIndexView`, `ControlCenterView`, `DreamMemoryView`, `KnowledgeGraphView`, `OrchestrationTasksView`, and `SecondBrainView`).
🎯 **Why:** To improve accessibility for keyboard users. These custom interactive elements lacked standard browser focus outlines (often explicitly disabled with `outline: 'none'`), making it difficult or impossible to track focus state while navigating via the keyboard.
📸 **Before/After:** Verified via local playwright screenshots, demonstrating the neon cyan focus ring properly outlining active switches and filter chips when navigating.
♿ **Accessibility:** This directly addresses WCAG 2.1 Success Criterion 2.4.7 (Focus Visible), ensuring that any keyboard operable user interface has a mode of operation where the keyboard focus indicator is visible.

---
*PR created automatically by Jules for task [10137568858353604026](https://jules.google.com/task/10137568858353604026) started by @giauphan*