### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing authentication on A2A Registry endpoints

### DIFF
--- a/src/presentation/a2a/a2aRoutes.ts
+++ b/src/presentation/a2a/a2aRoutes.ts
@@ -15,7 +15,7 @@ import { logger } from "../../utils/logger.js";
 import { authMiddleware } from "../../middleware/auth.js";
 import rateLimit from "express-rate-limit";
 
-const a2aRateLimiter = rateLimit({
+export const a2aRateLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
   max: 120, // limit each IP to 120 requests per windowMs
   standardHeaders: true,

--- a/src/presentation/a2a/heartbeatRoutes.ts
+++ b/src/presentation/a2a/heartbeatRoutes.ts
@@ -50,23 +50,27 @@ export function mountHeartbeatRoutes(app: express.Express): void {
   });
 
   // List agents
-  app.get("/a2a/agents", a2aRateLimiter, authMiddleware, async (_req, res) => {
-    const records = await a2aRegistry.listAll();
-    const agents = records.map(r => ({
-      agentId: r.agentId,
-      name: r.agentName,
-      url: r.agentUrl,
-      capabilities: r.capabilities,
-      status: r.status,
-      lastHeartbeat: r.lastHeartbeat.toISOString(),
-      registeredAt: r.registeredAt.toISOString(),
-    }));
+  app.get("/a2a/agents", a2aRateLimiter, authMiddleware, async (_req, res, next) => {
+    try {
+      const records = await a2aRegistry.listAll();
+      const agents = records.map(r => ({
+        agentId: r.agentId,
+        name: r.agentName,
+        url: r.agentUrl,
+        capabilities: r.capabilities,
+        status: r.status,
+        lastHeartbeat: r.lastHeartbeat.toISOString(),
+        registeredAt: r.registeredAt.toISOString(),
+      }));
 
-    res.json({
-      agentCount: agents.length,
-      onlineCount: agents.filter(a => a.status === "online").length,
-      agents: agents.sort((a, b) => a.status === "online" ? -1 : 1),
-    });
+      res.json({
+        agentCount: agents.length,
+        onlineCount: agents.filter(a => a.status === "online").length,
+        agents: agents.sort((a, b) => a.status === "online" ? -1 : 1),
+      });
+    } catch (err) {
+      next(err);
+    }
   });
 
   logger.info("[A2A Heartbeat] Routes mounted: /a2a/register, /a2a/heartbeat, /a2a/agents");

--- a/src/presentation/a2a/heartbeatRoutes.ts
+++ b/src/presentation/a2a/heartbeatRoutes.ts
@@ -11,11 +11,12 @@ import express from "express";
 import { a2aRegistry } from "../../services/a2aRegistry.js";
 import { logger } from "../../utils/logger.js";
 import { authMiddleware } from "../../middleware/auth.js";
+import { a2aRateLimiter } from "./a2aRoutes.js";
 
 export function mountHeartbeatRoutes(app: express.Express): void {
 
   // Register an agent
-  app.get("/a2a/register", authMiddleware, (req, res) => {
+  app.get("/a2a/register", a2aRateLimiter, authMiddleware, (req, res) => {
     const agentUrl = req.query.agent_url as string;
     const agentName = req.query.agent_name as string || "Unknown Agent";
     const capabilities = (req.query.capabilities as string || "").split(",").filter(Boolean);
@@ -38,7 +39,7 @@ export function mountHeartbeatRoutes(app: express.Express): void {
   });
 
   // Heartbeat ping
-  app.post("/a2a/heartbeat", authMiddleware, (req, res) => {
+  app.post("/a2a/heartbeat", a2aRateLimiter, authMiddleware, (req, res) => {
     const { agent_url } = req.body || {};
     if (!agent_url) {
       res.status(400).json({ error: "Missing agent_url" });
@@ -49,7 +50,8 @@ export function mountHeartbeatRoutes(app: express.Express): void {
   });
 
   // List agents
-  app.get("/a2a/agents", authMiddleware, async (_req, res) => {
+  app.get("/a2a/agents", a2aRateLimiter, authMiddleware, async (req, res) => {
+    // If agent listing should respect caller permissions, we use req.auth here
     const records = await a2aRegistry.listAll();
     const agents = records.map(r => ({
       agentId: r.agentId,

--- a/src/presentation/a2a/heartbeatRoutes.ts
+++ b/src/presentation/a2a/heartbeatRoutes.ts
@@ -50,8 +50,7 @@ export function mountHeartbeatRoutes(app: express.Express): void {
   });
 
   // List agents
-  app.get("/a2a/agents", a2aRateLimiter, authMiddleware, async (req, res) => {
-    // If agent listing should respect caller permissions, we use req.auth here
+  app.get("/a2a/agents", a2aRateLimiter, authMiddleware, async (_req, res) => {
     const records = await a2aRegistry.listAll();
     const agents = records.map(r => ({
       agentId: r.agentId,

--- a/src/presentation/a2a/heartbeatRoutes.ts
+++ b/src/presentation/a2a/heartbeatRoutes.ts
@@ -10,11 +10,12 @@
 import express from "express";
 import { a2aRegistry } from "../../services/a2aRegistry.js";
 import { logger } from "../../utils/logger.js";
+import { authMiddleware } from "../../middleware/auth.js";
 
 export function mountHeartbeatRoutes(app: express.Express): void {
 
   // Register an agent
-  app.get("/a2a/register", (req, res) => {
+  app.get("/a2a/register", authMiddleware, (req, res) => {
     const agentUrl = req.query.agent_url as string;
     const agentName = req.query.agent_name as string || "Unknown Agent";
     const capabilities = (req.query.capabilities as string || "").split(",").filter(Boolean);
@@ -37,7 +38,7 @@ export function mountHeartbeatRoutes(app: express.Express): void {
   });
 
   // Heartbeat ping
-  app.post("/a2a/heartbeat", (req, res) => {
+  app.post("/a2a/heartbeat", authMiddleware, (req, res) => {
     const { agent_url } = req.body || {};
     if (!agent_url) {
       res.status(400).json({ error: "Missing agent_url" });
@@ -48,7 +49,7 @@ export function mountHeartbeatRoutes(app: express.Express): void {
   });
 
   // List agents
-  app.get("/a2a/agents", async (_req, res) => {
+  app.get("/a2a/agents", authMiddleware, async (_req, res) => {
     const records = await a2aRegistry.listAll();
     const agents = records.map(r => ({
       agentId: r.agentId,


### PR DESCRIPTION
🎯 **What:** Added `authMiddleware` to the A2A registry endpoints in `src/presentation/a2a/heartbeatRoutes.ts`.

⚠️ **Risk:** Unauthenticated attackers could register unauthorized agents, spam the heartbeat, and list all active agents.

🛡️ **Solution:** By importing and adding `authMiddleware` to these routes, we ensure that every request requires a valid Firebase ID token or API key before reaching the route's business logic, preserving the integrity of the agent registry.

---
*PR created automatically by Jules for task [5507537765653492167](https://jules.google.com/task/5507537765653492167) started by @giauphan*