### PR TITLE
refactor(db): replace GRAPH_TABLE with detectCircularDependencies

### DIFF
--- a/src/database/adapters/postgresAdapter.ts
+++ b/src/database/adapters/postgresAdapter.ts
@@ -4,7 +4,7 @@ import { logger } from "../../utils/logger.js";
 
 // Lazy-loaded optional dependencies
 let Pool: typeof import("pg").Pool;
-let pgvector: typeof import("pgvector");
+let pgvector: any;
 
 const importPg = async () => {
   if (!Pool) {
@@ -15,8 +15,7 @@ const importPg = async () => {
 
 const importPgvector = async () => {
   if (!pgvector) {
-    // @ts-ignore: Dynamic import of optional dependency
-    const pgv = await import("pgvector/pg");
+    const pgv = await import("pgvector/pg" as any);
     pgvector = pgv;
   }
 };

--- a/src/database/adapters/postgresAdapter.ts
+++ b/src/database/adapters/postgresAdapter.ts
@@ -2,8 +2,11 @@
 import { IDatabaseAdapter, VectorSearchResult } from "./interface.js";
 import { logger } from "../../utils/logger.js";
 
+import { createRequire } from "module";
+
 // Lazy-loaded optional dependencies
-let { Pool } = require("pg");
+const require = createRequire(import.meta.url);
+let Pool: any;
 let pgvector: any;
 
 interface PgPool {

--- a/src/database/adapters/postgresAdapter.ts
+++ b/src/database/adapters/postgresAdapter.ts
@@ -3,21 +3,24 @@ import { IDatabaseAdapter, VectorSearchResult } from "./interface.js";
 import { logger } from "../../utils/logger.js";
 
 // Lazy-loaded optional dependencies
-let Pool: typeof import("pg").Pool;
-let pgvector: any;
+// Ensure TypeScript knows Pool is initialized when we construct it
+let Pool: typeof import("pg").Pool | undefined;
+
+let toSql: (value: number[] | Float32Array) => string;
+
+const importPgvector = async () => {
+  if (!toSql) {
+    const pgv = await import("pgvector/pg" as any);
+    toSql = pgv.toSql;
+  }
+};
 
 const importPg = async () => {
   if (!Pool) {
     const pg = await import("pg");
     Pool = pg.default ? pg.default.Pool || pg.Pool : pg.Pool;
   }
-};
-
-const importPgvector = async () => {
-  if (!pgvector) {
-    const pgv = await import("pgvector/pg" as any);
-    pgvector = pgv;
-  }
+  return Pool;
 };
 
 interface PgPool {
@@ -28,13 +31,10 @@ interface PgPool {
 export class PostgresAdapter implements IDatabaseAdapter {
   private pool: PgPool | null = null;
 
-  constructor() {
-    // Dynamic import initialization is handled in connect()
-  }
-
   async connect(): Promise<void> {
+    let pgPoolConstructor: typeof import("pg").Pool;
     try {
-      await importPg();
+      pgPoolConstructor = (await importPg())!;
       await importPgvector();
     } catch (err) {
       throw new Error(
@@ -42,7 +42,7 @@ export class PostgresAdapter implements IDatabaseAdapter {
       );
     }
 
-    this.pool = new Pool({
+    this.pool = new pgPoolConstructor({
       host: process.env.PGHOST,
       port: parseInt(process.env.PGPORT || "5432"),
       user: process.env.PGUSER,
@@ -93,7 +93,7 @@ export class PostgresAdapter implements IDatabaseAdapter {
 
   async searchVector(table: string, embedding: number[], limit: number, tenantId: string): Promise<VectorSearchResult[]> {
     const pool = await this.getConnection();
-    const embeddingVector = pgvector.toSql(embedding);
+    const embeddingVector = toSql(embedding);
     const sql = `
       SELECT id, 1 - (embedding <=> $1) AS score
       FROM ${table}

--- a/src/database/adapters/postgresAdapter.ts
+++ b/src/database/adapters/postgresAdapter.ts
@@ -2,12 +2,24 @@
 import { IDatabaseAdapter, VectorSearchResult } from "./interface.js";
 import { logger } from "../../utils/logger.js";
 
-import { createRequire } from "module";
-
 // Lazy-loaded optional dependencies
-const require = createRequire(import.meta.url);
-let Pool: any;
-let pgvector: any;
+let Pool: typeof import("pg").Pool;
+let pgvector: typeof import("pgvector");
+
+const importPg = async () => {
+  if (!Pool) {
+    const pg = await import("pg");
+    Pool = pg.default ? pg.default.Pool || pg.Pool : pg.Pool;
+  }
+};
+
+const importPgvector = async () => {
+  if (!pgvector) {
+    // @ts-ignore: Dynamic import of optional dependency
+    const pgv = await import("pgvector/pg");
+    pgvector = pgv;
+  }
+};
 
 interface PgPool {
   query: (sql: string, params?: any[]) => Promise<{ rows: any[]; rowCount: number }>;
@@ -18,17 +30,19 @@ export class PostgresAdapter implements IDatabaseAdapter {
   private pool: PgPool | null = null;
 
   constructor() {
+    // Dynamic import initialization is handled in connect()
+  }
+
+  async connect(): Promise<void> {
     try {
-      Pool = require("pg").Pool;
-      pgvector = require("pgvector");
+      await importPg();
+      await importPgvector();
     } catch (err) {
       throw new Error(
         "Postgres adapter requires 'pg' and 'pgvector'. Install: pnpm add pg pgvector"
       );
     }
-  }
 
-  async connect(): Promise<void> {
     this.pool = new Pool({
       host: process.env.PGHOST,
       port: parseInt(process.env.PGPORT || "5432"),

--- a/src/services/memoryService.ts
+++ b/src/services/memoryService.ts
@@ -3,6 +3,7 @@ import type { Connection } from "oracledb";
 import { authStorage } from "../utils/context.js";
 import { logger } from "../utils/logger.js";
 import { initPool, setSessionContext } from "../database/connection.js";
+import { createDatabaseAdapter } from "../database/factory.js";
 import { generateEmbedding, generateEmbeddingsBatch } from "./embeddingService.js";
 import type { GraphEntity, GraphLink, ArchSmells } from "../types/index.js";
 
@@ -263,15 +264,12 @@ export class OracleMemoryService {
 
   /**
    * Graph Analysis: Detect architectural smells (Circular Dependencies, God Objects, Dead Code)
-   * Utilizing SQL Property Graph Queries (Oracle 23ai+)
+   * Utilizing Database Adapters
    */
   static async detectArchitecturalSmells(project: string) {
-    let connection;
+    const adapter = createDatabaseAdapter();
     try {
-      const pool = await initPool();
-      connection = await pool.getConnection();
-      await setSessionContext(connection);
-
+      await adapter.connect();
       const tenantId = authStorage.getStore()!.uid;
 
       const smells: ArchSmells = {
@@ -280,49 +278,14 @@ export class OracleMemoryService {
         deadCode: []
       };
 
-      // 1. Detect Circular Dependencies (Cycles in the dependency graph) using SQL Graph queries
-      const circularSql = `
-          SELECT DISTINCT entity_name, file_path
-          FROM GRAPH_TABLE ( ai_knowledge_graph
-            MATCH (a)-[e IS ai_relational_memory]->{1,5}(a)
-            WHERE a.project_name = :project AND a.tenant_id = :tenantId
-            COLUMNS (a.entity_name, a.file_path)
-          )
-        `;
-      const circularRes = await OracleMemoryService.executeAsync(connection, circularSql, { project, tenantId: authStorage.getStore()!.uid });
-      smells.circularDependencies = (circularRes.rows ?? []) as unknown[];
+      // 1. Detect Circular Dependencies (Cycles in the dependency graph)
+      smells.circularDependencies = await adapter.detectCircularDependencies(project, tenantId) as unknown[];
 
       // 2. Detect God Objects (Entities with excessively high incoming relationships / high in-degree)
-      const godSql = `
-          SELECT entity_name, entity_type, file_path, in_degree
-          FROM (
-            SELECT target_id, count(*) as in_degree
-            FROM ai_relational_memory
-            WHERE project_name = :project AND tenant_id = :tenantId
-            GROUP BY target_id
-          ) r
-          JOIN ai_semantic_memory s ON r.target_id = s.id AND r.tenant_id = s.tenant_id
-          WHERE in_degree > 15
-          ORDER BY in_degree DESC
-          FETCH FIRST 10 ROWS ONLY
-        `;
-      const godRes = await OracleMemoryService.executeAsync(connection, godSql, { project, tenantId: authStorage.getStore()!.uid });
-      smells.godObjects = (godRes.rows ?? []) as unknown[];
+      smells.godObjects = await adapter.detectGodObjects(project, tenantId) as unknown[];
 
       // 3. Detect Dead Code (Entities with zero incoming relationships, and not main entry points)
-      const deadSql = `
-          SELECT entity_name, file_path
-          FROM ai_semantic_memory s
-          WHERE project_name = :project AND tenant_id = :tenantId
-            AND entity_type IN ('function', 'class')
-            AND NOT EXISTS (
-              SELECT 1 FROM ai_relational_memory r 
-              WHERE r.target_id = s.id
-            )
-          FETCH FIRST 20 ROWS ONLY
-        `;
-      const deadRes = await OracleMemoryService.executeAsync(connection, deadSql, { project, tenantId: authStorage.getStore()!.uid });
-      smells.deadCode = (deadRes.rows ?? []) as unknown[];
+      smells.deadCode = await adapter.detectDeadCode(project, tenantId) as unknown[];
 
       return smells;
 
@@ -330,12 +293,10 @@ export class OracleMemoryService {
       logger.error("Error detecting smells:", err instanceof Error ? err.message : String(err));
       throw err;
     } finally {
-      if (connection) {
-        try {
-          await connection.close();
-        } catch (closeErr) {
-          logger.error("Error closing connection:", closeErr);
-        }
+      try {
+        await adapter.disconnect();
+      } catch (closeErr) {
+        logger.error("Error closing database adapter connection:", closeErr);
       }
     }
   }


### PR DESCRIPTION
Fixes #161 by refactoring the `detectArchitecturalSmells` method to use the database adapter instead of hardcoding Oracle-specific SQL queries.

- Replaced `GRAPH_TABLE` SQL in `memoryService.ts` with `adapter.detectCircularDependencies()`.
- Added missing recursive CTE queries to `postgresAdapter.ts` and `sqliteAdapter.ts` so cycle detection functions properly in those dialects.
- Fixed a dynamically loaded module `require` issue in the `postgresAdapter` so `pnpm test` passes in an ESM environment.

---
*PR created automatically by Jules for task [14076888065420539255](https://jules.google.com/task/14076888065420539255) started by @giauphan*