### PR TITLE
🎨 Palette: Add keyboard focus rings to main navigation and auth

### DIFF
--- a/dashboard/src/components/Auth.tsx
+++ b/dashboard/src/components/Auth.tsx
@@ -114,7 +114,7 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
               onClick={() => { setMode(tab.id as 'token' | 'signin'); setError(null); }}
               className={FOCUS_RING_CLASS}
               style={{
-                flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', padding: '0.75rem', borderRadius: '12px', border: 'none', cursor: loading ? 'not-allowed' : 'pointer', fontSize: '0.75rem', fontWeight: 800, transition: 'all 0.3s',
+                flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', padding: '0.75rem', borderRadius: '12px', outline: 'none', border: 'none', cursor: loading ? 'not-allowed' : 'pointer', fontSize: '0.75rem', fontWeight: 800, transition: 'all 0.3s',
                 background: mode === tab.id ? 'rgba(255,255,255,0.1)' : 'transparent',
                 color: mode === tab.id ? '#fff' : 'var(--text-muted)',
                 opacity: loading ? 0.5 : 1

--- a/dashboard/src/components/Auth.tsx
+++ b/dashboard/src/components/Auth.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import { safeSessionStorageSetItem, safeSessionStorageGetItem, safeSessionStorageRemoveItem } from '../lib/safeSessionStorage';
 import { storeAuthTokens } from '../lib/auth';
+import { FOCUS_RING_CLASS } from '../lib/constants';
 
 interface AuthProps {
   onLogin: (key: string) => void;
@@ -111,6 +112,7 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
               key={tab.id}
               disabled={loading}
               onClick={() => { setMode(tab.id as 'token' | 'signin'); setError(null); }}
+              className={FOCUS_RING_CLASS}
               style={{
                 flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', padding: '0.75rem', borderRadius: '12px', border: 'none', cursor: loading ? 'not-allowed' : 'pointer', fontSize: '0.75rem', fontWeight: 800, transition: 'all 0.3s',
                 background: mode === tab.id ? 'rgba(255,255,255,0.1)' : 'transparent',

--- a/dashboard/src/components/Dashboard.tsx
+++ b/dashboard/src/components/Dashboard.tsx
@@ -34,6 +34,7 @@ import { OrchestrationTasksView } from './OrchestrationTasksView';
 import { safeSessionStorageSetItem, safeSessionStorageGetItem, safeSessionStorageRemoveItem } from '../lib/safeSessionStorage';
 import { getAuthHeaders } from '../lib/auth';
 import { setCacheItem, getCacheItem, removeCacheItem, clearCache } from '../lib/db';
+import { FOCUS_RING_CLASS } from '../lib/constants';
 
 // API Configuration
 const API_BASE = window.location.origin.includes('localhost:5173')
@@ -536,6 +537,7 @@ export const Dashboard: React.FC = () => {
                 <button
                   onClick={() => setActiveTab(tab)}
                   aria-current={activeTab === tab ? 'page' : undefined}
+                  className={FOCUS_RING_CLASS}
                   style={{
                     width: '100%', padding: '0.75rem 1rem', borderRadius: '8px',
                     background: activeTab === tab ? 'var(--button-active-background)' : 'transparent',
@@ -569,6 +571,7 @@ export const Dashboard: React.FC = () => {
           )}
           <button
             onClick={clearAllCaches}
+            className={FOCUS_RING_CLASS}
             style={{
               width: '100%', padding: '0.75rem 1rem', borderRadius: '8px',
               background: 'transparent', color: 'var(--text-muted)',

--- a/dashboard/src/components/Dashboard.tsx
+++ b/dashboard/src/components/Dashboard.tsx
@@ -542,7 +542,7 @@ export const Dashboard: React.FC = () => {
                     width: '100%', padding: '0.75rem 1rem', borderRadius: '8px',
                     background: activeTab === tab ? 'var(--button-active-background)' : 'transparent',
                     color: activeTab === tab ? 'var(--primary-neon)' : 'var(--text-muted)',
-                    border: 'none', textAlign: 'left', cursor: 'pointer',
+                    outline: 'none', border: 'none', textAlign: 'left', cursor: 'pointer',
                     fontSize: '1rem', display: 'flex', alignItems: 'center', gap: '0.75rem',
                     transition: 'all 0.3s ease',
                     boxShadow: activeTab === tab ? '0 0 15px rgba(0, 240, 255, 0.2)' : 'none'
@@ -575,7 +575,7 @@ export const Dashboard: React.FC = () => {
             style={{
               width: '100%', padding: '0.75rem 1rem', borderRadius: '8px',
               background: 'transparent', color: 'var(--text-muted)',
-              border: 'none', textAlign: 'left', cursor: 'pointer',
+              outline: 'none', border: 'none', textAlign: 'left', cursor: 'pointer',
               fontSize: '1rem', display: 'flex', alignItems: 'center', gap: '0.75rem',
               transition: 'all 0.3s ease'
             }}


### PR DESCRIPTION
💡 **What**: Added `FOCUS_RING_CLASS` from `constants` to `Dashboard` navigation tabs, `Dashboard` logout button, and `Auth` mode toggle tabs.
🎯 **Why**: Previously, when navigating via keyboard, these interactive elements lacked a visual focus indicator, making it difficult for users relying on keyboard navigation to know which element was currently active or focused. This solves a direct accessibility issue.
📸 **Before/After**: Keyboard focus rings are now visible on navigation and auth tabs, as verified in screenshots.
♿ **Accessibility**: Significant improvement for keyboard-only users who can now clearly see the active focus state on primary navigation elements.

---
*PR created automatically by Jules for task [11273294778446214883](https://jules.google.com/task/11273294778446214883) started by @giauphan*