### PR TITLE
refactor(db): replace MERGE INTO with ON CONFLICT in dreamingService (#158)

### DIFF
--- a/src/services/dreamingService.ts
+++ b/src/services/dreamingService.ts
@@ -433,58 +433,94 @@ export class OracleDreamingService {
     // Content hash for dedup — same content always produces same hash
     const contentHash = crypto.createHash('sha256').update(content).digest('hex');
 
-    let connection;
+    const db = createDatabaseAdapter();
+    const tenantId = authStorage.getStore()!.uid;
+    const id = `${project}_${memoryType}_${sessionId}_${Date.now()}`;
+    const initialConfidence = OracleDreamingService.calcInitialConfidence(memoryType, importance);
+    const tagsJson = tags ? JSON.stringify(tags) : null;
+    const relatedIdsJson = relatedIds ? JSON.stringify(relatedIds) : null;
+    const dbType = (process.env.CODEATLAS_DB_TYPE || "oracle").toLowerCase();
+
     try {
-      const pool = await initPool();
-      connection = await pool.getConnection();
-      await setSessionContext(connection);
-
-      const tenantId = authStorage.getStore()!.uid;
-      const id = `${project}_${memoryType}_${sessionId}_${Date.now()}`;
-      const initialConfidence = OracleDreamingService.calcInitialConfidence(memoryType, importance);
-      const tagsJson = tags ? JSON.stringify(tags) : null;
-      const relatedIdsJson = relatedIds ? JSON.stringify(relatedIds) : null;
-
       if (OracleDreamingService._hasContentHashColumn && OracleDreamingService._hasLifecycleColumns) {
-        // Full MERGE with dedup on content_hash (preferred path)
-        const sql = `
-          MERGE INTO ai_dreaming_memory trg
-          USING (SELECT :project AS project, :memoryType AS memory_type, :contentHash AS content_hash, :tenantId AS tenant_id FROM DUAL) src
-          ON (trg.project = src.project AND trg.memory_type = src.memory_type AND trg.content_hash = src.content_hash AND trg.tenant_id = src.tenant_id)
-          WHEN MATCHED THEN
-            UPDATE SET
-              embedding      = :embedding,
-              importance     = GREATEST(trg.importance, :importance),
-              content        = :content,
-              session_id     = :sessionId,
-              provider       = :provider,
-              id             = :id,
-              confidence     = GREATEST(trg.confidence, :initialConfidence),
-              evidence_count = trg.evidence_count + 1,
-              scope          = COALESCE(:scope, trg.scope),
-              tags           = COALESCE(TO_CLOB(:tagsJson), trg.tags),
-              related_ids    = COALESCE(TO_CLOB(:relatedIdsJson), trg.related_ids)
-          WHEN NOT MATCHED THEN
-            INSERT (id, session_id, project, provider, memory_type, content, embedding, importance, content_hash, confidence, status, evidence_count, access_count, version, tenant_id, scope, tags, related_ids)
-            VALUES (:id, :sessionId, :project, :provider, :memoryType, :content, :embedding, :importance, :contentHash, :initialConfidence, 'active', 1, 0, 1, :tenantId, :scope, :tagsJson, :relatedIdsJson)
-        `;
+        if (dbType === "postgres" || dbType === "sqlite") {
+          const sql = `
+            INSERT INTO ai_dreaming_memory (
+              id, session_id, project, provider, memory_type, content, embedding, importance, content_hash, confidence, status, evidence_count, access_count, version, tenant_id, scope, tags, related_ids
+            ) VALUES (
+              :id, :sessionId, :project, :provider, :memoryType, :content, :embedding, :importance, :contentHash, :initialConfidence, 'active', 1, 0, 1, :tenantId, :scope, :tagsJson, :relatedIdsJson
+            )
+            ON CONFLICT(project, memory_type, content_hash, tenant_id) DO UPDATE SET
+              embedding      = EXCLUDED.embedding,
+              importance     = CASE WHEN ai_dreaming_memory.importance > EXCLUDED.importance THEN ai_dreaming_memory.importance ELSE EXCLUDED.importance END,
+              content        = EXCLUDED.content,
+              session_id     = EXCLUDED.session_id,
+              provider       = EXCLUDED.provider,
+              id             = EXCLUDED.id,
+              confidence     = CASE WHEN ai_dreaming_memory.confidence > EXCLUDED.confidence THEN ai_dreaming_memory.confidence ELSE EXCLUDED.confidence END,
+              evidence_count = ai_dreaming_memory.evidence_count + 1,
+              scope          = COALESCE(EXCLUDED.scope, ai_dreaming_memory.scope),
+              tags           = COALESCE(EXCLUDED.tags, ai_dreaming_memory.tags),
+              related_ids    = COALESCE(EXCLUDED.related_ids, ai_dreaming_memory.related_ids)
+          `;
 
-        await connection.execute(sql, {
-          id,
-          sessionId,
-          project,
-          provider: aiModel ?? null,
-          memoryType,
-          content,
-          contentHash,
-          embedding: embeddingVector ? new Float32Array(embeddingVector) : null,
-          importance,
-          initialConfidence,
-          tenantId,
-          scope: scope ?? null,
-          tagsJson,
-          relatedIdsJson
-        } as oracledb.BindParameters, { autoCommit: true });
+          await db.execute(sql, {
+            id,
+            sessionId,
+            project,
+            provider: aiModel ?? null,
+            memoryType,
+            content,
+            contentHash,
+            embedding: embeddingVector ? (dbType === "sqlite" ? new Uint8Array(new Float32Array(embeddingVector).buffer) : new Float32Array(embeddingVector)) : null,
+            importance,
+            initialConfidence,
+            tenantId,
+            scope: scope ?? null,
+            tagsJson,
+            relatedIdsJson
+          });
+        } else {
+          // Full MERGE with dedup on content_hash (preferred path for Oracle)
+          const sql = `
+            MERGE INTO ai_dreaming_memory trg
+            USING (SELECT :project AS project, :memoryType AS memory_type, :contentHash AS content_hash, :tenantId AS tenant_id FROM DUAL) src
+            ON (trg.project = src.project AND trg.memory_type = src.memory_type AND trg.content_hash = src.content_hash AND trg.tenant_id = src.tenant_id)
+            WHEN MATCHED THEN
+              UPDATE SET
+                embedding      = :embedding,
+                importance     = GREATEST(trg.importance, :importance),
+                content        = :content,
+                session_id     = :sessionId,
+                provider       = :provider,
+                id             = :id,
+                confidence     = GREATEST(trg.confidence, :initialConfidence),
+                evidence_count = trg.evidence_count + 1,
+                scope          = COALESCE(:scope, trg.scope),
+                tags           = COALESCE(TO_CLOB(:tagsJson), trg.tags),
+                related_ids    = COALESCE(TO_CLOB(:relatedIdsJson), trg.related_ids)
+            WHEN NOT MATCHED THEN
+              INSERT (id, session_id, project, provider, memory_type, content, embedding, importance, content_hash, confidence, status, evidence_count, access_count, version, tenant_id, scope, tags, related_ids)
+              VALUES (:id, :sessionId, :project, :provider, :memoryType, :content, :embedding, :importance, :contentHash, :initialConfidence, 'active', 1, 0, 1, :tenantId, :scope, :tagsJson, :relatedIdsJson)
+          `;
+
+          await db.execute(sql, {
+            id,
+            sessionId,
+            project,
+            provider: aiModel ?? null,
+            memoryType,
+            content,
+            contentHash,
+            embedding: embeddingVector ? new Float32Array(embeddingVector) : null,
+            importance,
+            initialConfidence,
+            tenantId,
+            scope: scope ?? null,
+            tagsJson,
+            relatedIdsJson
+          });
+        }
       } else {
         // Fallback: simple INSERT when content_hash column is missing
         const cols = OracleDreamingService._hasLifecycleColumns
@@ -497,10 +533,9 @@ export class OracleDreamingService {
           ? { id, sessionId, project, provider: aiModel ?? null, memoryType, content, embedding: embeddingVector ? new Float32Array(embeddingVector) : null, importance, initialConfidence, tenantId, scope: scope ?? null, tagsJson, relatedIdsJson }
           : { id, sessionId, project, provider: aiModel ?? null, memoryType, content, embedding: embeddingVector ? new Float32Array(embeddingVector) : null, importance, tenantId, scope: scope ?? null, tagsJson, relatedIdsJson };
 
-        await connection.execute(
+        await db.execute(
           `INSERT INTO ai_dreaming_memory (${cols}) VALUES (${vals})`,
-          binds as oracledb.BindParameters,
-          { autoCommit: true }
+          binds
         );
       }
 
@@ -509,14 +544,6 @@ export class OracleDreamingService {
     } catch (err) {
       logger.error("[Oracle Dreaming] Error saving dream memory:", err instanceof Error ? err.message : String(err));
       throw err;
-    } finally {
-      if (connection) {
-        try {
-          await connection.close();
-        } catch (closeErr) {
-          logger.error("[Oracle Dreaming] Error closing connection:", closeErr);
-        }
-      }
     }
   }
 

--- a/tests/unit/dreaming-service.test.ts
+++ b/tests/unit/dreaming-service.test.ts
@@ -40,6 +40,8 @@ mock.module(path.join(srcDir, 'database/connection.js'), {
 
 // Mock database/factory.ts
 const mockDbAdapter = {
+  execute: mock.fn(() => Promise.resolve({ rowsAffected: 1 })),
+  query: mock.fn(() => Promise.resolve([])),
   searchVector: mock.fn(() => Promise.resolve([
     { id: 'memory_1', score: 0.9 },
     { id: 'memory_2', score: 0.8 },
@@ -100,6 +102,9 @@ describe('OracleDreamingService', () => {
     mockConnection.execute.mock.resetCalls();
     mockConnection.close.mock.resetCalls();
     mockPool.getConnection.mock.resetCalls();
+    mockDbAdapter.execute.mock.resetCalls();
+    mockDbAdapter.query.mock.resetCalls();
+    mockDbAdapter.searchVector.mock.resetCalls();
     mockGenerateEmbedding.mock.resetCalls();
     mockAuthStore.getStore.mock.resetCalls();
     mockAuthStore.run.mock.resetCalls();
@@ -124,7 +129,7 @@ describe('OracleDreamingService', () => {
   // ── saveDreamMemory ────────────────────────────────────────────────
   describe('saveDreamMemory()', () => {
     test('with valid inputs returns id string', async () => {
-      mockConnection.execute.mock.mockImplementation(async () => {
+      mockDbAdapter.execute.mock.mockImplementation(async () => {
         return { rowsAffected: 1 };
       });
 
@@ -147,26 +152,15 @@ describe('OracleDreamingService', () => {
         'passage',
       );
 
-      // Should have acquired a connection
-      assert.strictEqual(mockPool.getConnection.mock.calls.length, 1);
-      // Should have set session context
-      const { initPool, setSessionContext } = await import(
-        path.join(srcDir, 'database/connection.js')
-      );
-      assert.strictEqual(setSessionContext.mock.calls.length, 1);
-
-      // Should have executed the INSERT
-      assert.strictEqual(mockConnection.execute.mock.calls.length, 1);
-      const insertSql = mockConnection.execute.mock.calls[0].arguments[0] as string;
-      assert.ok(insertSql.includes('INSERT INTO ai_dreaming_memory'));
-
-      // Should have closed the connection
-      assert.strictEqual(mockConnection.close.mock.calls.length, 1);
+      // Should have executed the statement via adapter
+      assert.strictEqual(mockDbAdapter.execute.mock.calls.length, 1);
+      const insertSql = mockDbAdapter.execute.mock.calls[0].arguments[0] as string;
+      assert.ok(insertSql.includes('ai_dreaming_memory'));
     });
 
     test('without embedding (null vector) still saves correctly', async () => {
       mockGenerateEmbedding.mock.mockImplementation(() => Promise.resolve(null));
-      mockConnection.execute.mock.mockImplementation(async () => {
+      mockDbAdapter.execute.mock.mockImplementation(async () => {
         return { rowsAffected: 1 };
       });
 
@@ -180,15 +174,15 @@ describe('OracleDreamingService', () => {
       // Embedding was attempted but returned null
       assert.strictEqual(mockGenerateEmbedding.mock.calls.length, 1);
 
-      // INSERT still executed (with null embedding)
-      assert.strictEqual(mockConnection.execute.mock.calls.length, 1);
-      const binds = mockConnection.execute.mock.calls[0].arguments[1] as Record<string, unknown>;
+      // statement still executed (with null embedding)
+      assert.strictEqual(mockDbAdapter.execute.mock.calls.length, 1);
+      const binds = mockDbAdapter.execute.mock.calls[0].arguments[1] as Record<string, unknown>;
       // embedding should be null when generateEmbedding returns null
       assert.strictEqual(binds.embedding, null);
     });
 
     test('with DB error throws error', async () => {
-      mockConnection.execute.mock.mockImplementation(async () => {
+      mockDbAdapter.execute.mock.mockImplementation(async () => {
         throw new Error('ORA-00001: unique constraint violated');
       });
 
@@ -202,14 +196,12 @@ describe('OracleDreamingService', () => {
         },
       );
 
-      // Connection should still be closed after error
-      assert.strictEqual(mockConnection.close.mock.calls.length, 1);
       // Error should have been logged
-      assert.strict(mockLogger.error.mock.calls.length >= 1, true);
+      assert.ok(mockLogger.error.mock.calls.length >= 1);
     });
 
     test('with scope, tags, related_ids and SESSION_SUMMARY memory type saves correctly', async () => {
-      mockConnection.execute.mock.mockImplementation(async () => {
+      mockDbAdapter.execute.mock.mockImplementation(async () => {
         return { rowsAffected: 1 };
       });
 
@@ -222,8 +214,8 @@ describe('OracleDreamingService', () => {
       assert.ok(id);
       assert.ok(id.includes('SESSION_SUMMARY'));
 
-      assert.strictEqual(mockConnection.execute.mock.calls.length, 1);
-      const binds = mockConnection.execute.mock.calls[0].arguments[1] as Record<string, unknown>;
+      assert.strictEqual(mockDbAdapter.execute.mock.calls.length, 1);
+      const binds = mockDbAdapter.execute.mock.calls[0].arguments[1] as Record<string, unknown>;
       assert.strictEqual(binds.scope, 'auth/login');
       assert.strictEqual(binds.tagsJson, JSON.stringify(['jwt', 'security']));
       assert.strictEqual(binds.relatedIdsJson, JSON.stringify(['rel-1', 'rel-2']));


### PR DESCRIPTION
## Summary
- Replace `MERGE INTO` with `INSERT ... ON CONFLICT` for SQLite and Postgres in `saveDreamMemory`
- Wire `createDatabaseAdapter()` into `saveDreamMemory`
- Update unit test mocks in `dreaming-service.test.ts`

Closes #158