### PR TITLE
🎨 Palette: [UX improvement] Add focus rings to interactive elements for better accessibility

### DIFF
--- a/dashboard/src/components/ControlCenterView.tsx
+++ b/dashboard/src/components/ControlCenterView.tsx
@@ -196,7 +196,7 @@ const freqLabels: Record<string, string> = {
                     style={{
                       width: '44px', height: '24px', borderRadius: '12px', border: 'none', cursor: 'pointer',
                       background: cronEnabled ? 'var(--primary-neon)' : 'rgba(255,255,255,0.2)',
-                      position: 'relative', transition: '0.2s', outline: 'none'
+                      position: 'relative', transition: '0.2s'
                     }}>
                     <div style={{
                       width: '18px', height: '18px', borderRadius: '50%', background: '#fff',

--- a/dashboard/src/components/ControlCenterView.tsx
+++ b/dashboard/src/components/ControlCenterView.tsx
@@ -211,7 +211,7 @@ const freqLabels: Record<string, string> = {
                   style={{
                     width: '100%', padding: '0.85rem', borderRadius: '12px', border: '1px solid var(--primary-neon)',
                     background: 'rgba(0,240,255,0.1)', color: '#fff', fontWeight: 800, cursor: 'pointer', fontSize: '0.95rem',
-                    display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', outline: 'none'
+                    display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem'
                   }}>
                   {cronSaving ? <><RefreshCw className="animate-spin" size={20} /> SAVING...</> : (
                     <><Save size={18} />{cronSaved ? '✅ SAVED' : 'SAVE SCHEDULE'}</>
@@ -231,14 +231,14 @@ const freqLabels: Record<string, string> = {
               <div style={{ fontFamily: 'monospace', fontSize: '0.85rem', wordBreak: 'break-all', padding: '1rem', borderRadius: '12px', background: 'rgba(0,255,0,0.05)', border: '1px solid rgba(0,255,0,0.2)', marginBottom: '1rem' }}>
                 {createdKey}
               </div>
-              <button onClick={clearCreatedKey} className={`btn-neon-cyan ${FOCUS_RING_CLASS}`} style={{ width: '100%', outline: 'none' }}>DISMISS</button>
+              <button onClick={clearCreatedKey} className={`btn-neon-cyan ${FOCUS_RING_CLASS}`} style={{ width: '100%' }}>DISMISS</button>
             </motion.div>
           )}
 
           <div className="glass-panel" style={{ padding: '2rem', borderRadius: '32px', border: '1px solid rgba(255,255,255,0.05)', alignSelf: 'start' }}>
             <h3 className="tech-font" style={{ fontSize: '1.25rem', marginBottom: '1.5rem', fontWeight: 800 }}>GENERATE TOKEN</h3>
             <form onSubmit={createKey} style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
-              <button type="submit" className={`btn-neon-cyan ${FOCUS_RING_CLASS}`} style={{ width: '100%', height: '54px', fontSize: '1rem', fontWeight: 800, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', outline: 'none' }} disabled={loading}>
+              <button type="submit" className={`btn-neon-cyan ${FOCUS_RING_CLASS}`} style={{ width: '100%', height: '54px', fontSize: '1rem', fontWeight: 800, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem' }} disabled={loading}>
                 {loading ? <><RefreshCw className="animate-spin" size={20} /> CREATING...</> : 'CREATE ACCESS TOKEN'}
               </button>
             </form>

--- a/dashboard/src/components/ControlCenterView.tsx
+++ b/dashboard/src/components/ControlCenterView.tsx
@@ -207,6 +207,7 @@ const freqLabels: Record<string, string> = {
                 </div>
 
                 <button onClick={saveCron} disabled={cronSaving}
+                  className={FOCUS_RING_CLASS}
                   style={{
                     width: '100%', padding: '0.85rem', borderRadius: '12px', border: '1px solid var(--primary-neon)',
                     background: 'rgba(0,240,255,0.1)', color: '#fff', fontWeight: 800, cursor: 'pointer', fontSize: '0.95rem',
@@ -230,14 +231,14 @@ const freqLabels: Record<string, string> = {
               <div style={{ fontFamily: 'monospace', fontSize: '0.85rem', wordBreak: 'break-all', padding: '1rem', borderRadius: '12px', background: 'rgba(0,255,0,0.05)', border: '1px solid rgba(0,255,0,0.2)', marginBottom: '1rem' }}>
                 {createdKey}
               </div>
-              <button onClick={clearCreatedKey} className="btn-neon-cyan" style={{ width: '100%' }}>DISMISS</button>
+              <button onClick={clearCreatedKey} className={`btn-neon-cyan ${FOCUS_RING_CLASS}`} style={{ width: '100%' }}>DISMISS</button>
             </motion.div>
           )}
 
           <div className="glass-panel" style={{ padding: '2rem', borderRadius: '32px', border: '1px solid rgba(255,255,255,0.05)', alignSelf: 'start' }}>
             <h3 className="tech-font" style={{ fontSize: '1.25rem', marginBottom: '1.5rem', fontWeight: 800 }}>GENERATE TOKEN</h3>
             <form onSubmit={createKey} style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
-              <button type="submit" className="btn-neon-cyan" style={{ width: '100%', height: '54px', fontSize: '1rem', fontWeight: 800, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem' }} disabled={loading}>
+              <button type="submit" className={`btn-neon-cyan ${FOCUS_RING_CLASS}`} style={{ width: '100%', height: '54px', fontSize: '1rem', fontWeight: 800, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem' }} disabled={loading}>
                 {loading ? <><RefreshCw className="animate-spin" size={20} /> CREATING...</> : 'CREATE ACCESS TOKEN'}
               </button>
             </form>

--- a/dashboard/src/components/ControlCenterView.tsx
+++ b/dashboard/src/components/ControlCenterView.tsx
@@ -211,7 +211,7 @@ const freqLabels: Record<string, string> = {
                   style={{
                     width: '100%', padding: '0.85rem', borderRadius: '12px', border: '1px solid var(--primary-neon)',
                     background: 'rgba(0,240,255,0.1)', color: '#fff', fontWeight: 800, cursor: 'pointer', fontSize: '0.95rem',
-                    display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem'
+                    display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', outline: 'none'
                   }}>
                   {cronSaving ? <><RefreshCw className="animate-spin" size={20} /> SAVING...</> : (
                     <><Save size={18} />{cronSaved ? '✅ SAVED' : 'SAVE SCHEDULE'}</>
@@ -231,14 +231,14 @@ const freqLabels: Record<string, string> = {
               <div style={{ fontFamily: 'monospace', fontSize: '0.85rem', wordBreak: 'break-all', padding: '1rem', borderRadius: '12px', background: 'rgba(0,255,0,0.05)', border: '1px solid rgba(0,255,0,0.2)', marginBottom: '1rem' }}>
                 {createdKey}
               </div>
-              <button onClick={clearCreatedKey} className={`btn-neon-cyan ${FOCUS_RING_CLASS}`} style={{ width: '100%' }}>DISMISS</button>
+              <button onClick={clearCreatedKey} className={`btn-neon-cyan ${FOCUS_RING_CLASS}`} style={{ width: '100%', outline: 'none' }}>DISMISS</button>
             </motion.div>
           )}
 
           <div className="glass-panel" style={{ padding: '2rem', borderRadius: '32px', border: '1px solid rgba(255,255,255,0.05)', alignSelf: 'start' }}>
             <h3 className="tech-font" style={{ fontSize: '1.25rem', marginBottom: '1.5rem', fontWeight: 800 }}>GENERATE TOKEN</h3>
             <form onSubmit={createKey} style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
-              <button type="submit" className={`btn-neon-cyan ${FOCUS_RING_CLASS}`} style={{ width: '100%', height: '54px', fontSize: '1rem', fontWeight: 800, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem' }} disabled={loading}>
+              <button type="submit" className={`btn-neon-cyan ${FOCUS_RING_CLASS}`} style={{ width: '100%', height: '54px', fontSize: '1rem', fontWeight: 800, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', outline: 'none' }} disabled={loading}>
                 {loading ? <><RefreshCw className="animate-spin" size={20} /> CREATING...</> : 'CREATE ACCESS TOKEN'}
               </button>
             </form>

--- a/dashboard/src/components/ControlCenterView.tsx
+++ b/dashboard/src/components/ControlCenterView.tsx
@@ -183,6 +183,7 @@ const freqLabels: Record<string, string> = {
                   <input type="text" value={cronSchedule} onChange={e => setCronSchedule(e.target.value)}
                     placeholder="Custom cron (e.g. 0 19 * * *)"
                     aria-label="Custom cron frequency"
+                    className={FOCUS_RING_CLASS}
                     style={{ width: '100%', marginTop: '0.5rem', padding: '0.75rem 1rem', borderRadius: '12px',
                       border: '1px solid rgba(255,255,255,0.1)', background: 'rgba(255,255,255,0.05)',
                       color: '#fff', fontSize: '0.85rem', fontFamily: 'monospace' }}

--- a/dashboard/src/components/DreamMemoryView.tsx
+++ b/dashboard/src/components/DreamMemoryView.tsx
@@ -306,7 +306,7 @@ export function DreamMemoryView() {
           className={FOCUS_RING_CLASS}
           style={{
             padding: '0.75rem 1.25rem', borderRadius: '12px', border: '1px solid rgba(255,255,255,0.1)',
-            background: 'rgba(255,255,255,0.05)', color: '#fff', fontWeight: 700, cursor: 'pointer', outline: 'none'
+            background: 'rgba(255,255,255,0.05)', color: '#fff', fontWeight: 700, cursor: 'pointer'
           }}>
           <Settings size={18} style={{ marginRight: '0.5rem' }} /> Config
         </button>
@@ -355,8 +355,7 @@ export function DreamMemoryView() {
               padding: '0.4rem 1rem', borderRadius: '100px', cursor: 'pointer', fontSize: '0.8rem', fontWeight: 700,
               background: selectedTypes.includes(type) ? `${typeColors[type]}22` : 'rgba(255,255,255,0.05)',
               border: `1px solid ${selectedTypes.includes(type) ? typeColors[type] : 'rgba(255,255,255,0.1)'}`,
-              color: selectedTypes.includes(type) ? typeColors[type] : 'var(--text-muted)',
-              outline: 'none'
+              color: selectedTypes.includes(type) ? typeColors[type] : 'var(--text-muted)'
             }}
             className={FOCUS_RING_CLASS}
           >

--- a/dashboard/src/components/DreamMemoryView.tsx
+++ b/dashboard/src/components/DreamMemoryView.tsx
@@ -284,7 +284,8 @@ export function DreamMemoryView() {
                 borderRadius: '8px',
                 cursor: 'pointer',
                 fontSize: '0.8rem',
-                fontWeight: 600
+                fontWeight: 600,
+                outline: 'none'
               }}
             >
               Clear
@@ -314,7 +315,7 @@ export function DreamMemoryView() {
           className={FOCUS_RING_CLASS}
           style={{
             padding: '0.75rem 1.25rem', borderRadius: '12px', border: showAll ? '1px solid var(--primary-neon)' : '1px solid rgba(255,255,255,0.1)',
-            background: showAll ? 'rgba(0,240,255,0.1)' : 'rgba(255,255,255,0.05)', color: '#fff', fontWeight: 700, cursor: 'pointer'
+            background: showAll ? 'rgba(0,240,255,0.1)' : 'rgba(255,255,255,0.05)', color: '#fff', fontWeight: 700, cursor: 'pointer', outline: 'none'
           }}>
           {showAll ? 'All Projects' : 'GolikeTool'}
         </button>
@@ -335,10 +336,10 @@ export function DreamMemoryView() {
             <label htmlFor="config-provider">Provider:</label>
             <input id="config-provider" type="text" value={tempProvider} onChange={e => setTempProvider(e.target.value)} style={{ padding: '0.5rem' }} />
           </div>
-          <button onClick={saveDreamConfig} disabled={savingConfig} className={FOCUS_RING_CLASS} style={{ padding: '0.5rem 1rem' }}>
+          <button onClick={saveDreamConfig} disabled={savingConfig} className={FOCUS_RING_CLASS} style={{ padding: '0.5rem 1rem', outline: 'none' }}>
             {savingConfig ? 'Saving...' : 'Save Config'}
           </button>
-          <button onClick={runDailyDreamsNow} disabled={savingConfig} className={FOCUS_RING_CLASS} style={{ padding: '0.5rem 1rem', background: 'var(--primary-neon)', color: '#000' }}>
+          <button onClick={runDailyDreamsNow} disabled={savingConfig} className={FOCUS_RING_CLASS} style={{ padding: '0.5rem 1rem', background: 'var(--primary-neon)', color: '#000', outline: 'none' }}>
             Run Now
           </button>
         </div>
@@ -446,7 +447,7 @@ export function DreamMemoryView() {
             padding: '0.5rem 1rem', borderRadius: '8px', border: '1px solid rgba(255,255,255,0.2)',
             background: hasPrev ? 'rgba(0,240,255,0.1)' : 'rgba(255,255,255,0.05)',
             color: hasPrev ? 'var(--primary-neon)' : 'var(--text-muted)',
-            cursor: hasPrev ? 'pointer' : 'default', fontWeight: 700, fontSize: '0.85rem'
+            cursor: hasPrev ? 'pointer' : 'default', fontWeight: 700, fontSize: '0.85rem', outline: 'none'
           }}>
           ← Prev
         </button>
@@ -459,7 +460,7 @@ export function DreamMemoryView() {
             padding: '0.5rem 1rem', borderRadius: '8px', border: '1px solid rgba(255,255,255,0.2)',
             background: hasNext ? 'rgba(0,240,255,0.1)' : 'rgba(255,255,255,0.05)',
             color: hasNext ? 'var(--primary-neon)' : 'var(--text-muted)',
-            cursor: hasNext ? 'pointer' : 'default', fontWeight: 700, fontSize: '0.85rem'
+            cursor: hasNext ? 'pointer' : 'default', fontWeight: 700, fontSize: '0.85rem', outline: 'none'
           }}>
           Next →
         </button>

--- a/dashboard/src/components/DreamMemoryView.tsx
+++ b/dashboard/src/components/DreamMemoryView.tsx
@@ -238,14 +238,14 @@ export function DreamMemoryView() {
               setStartDate(e.target.value);
               setPage(0);
             }}
+            className={FOCUS_RING_CLASS}
             style={{
               padding: '0.5rem',
               borderRadius: '8px',
               border: '1px solid rgba(255,255,255,0.1)',
               background: 'rgba(0,0,0,0.2)',
               color: '#fff',
-              fontSize: '0.85rem',
-              outline: 'none'
+              fontSize: '0.85rem'
             }}
           />
           <span style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>to</span>
@@ -257,14 +257,14 @@ export function DreamMemoryView() {
               setEndDate(e.target.value);
               setPage(0);
             }}
+            className={FOCUS_RING_CLASS}
             style={{
               padding: '0.5rem',
               borderRadius: '8px',
               border: '1px solid rgba(255,255,255,0.1)',
               background: 'rgba(0,0,0,0.2)',
               color: '#fff',
-              fontSize: '0.85rem',
-              outline: 'none'
+              fontSize: '0.85rem'
             }}
           />
           {(startDate || endDate) && (

--- a/dashboard/src/components/DreamMemoryView.tsx
+++ b/dashboard/src/components/DreamMemoryView.tsx
@@ -325,15 +325,15 @@ export function DreamMemoryView() {
         <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
             <label htmlFor="config-enabled">Enabled:</label>
-            <input id="config-enabled" type="checkbox" checked={tempEnabled} onChange={e => setTempEnabled(e.target.checked)} />
+            <input id="config-enabled" type="checkbox" checked={tempEnabled} onChange={e => setTempEnabled(e.target.checked)} className={FOCUS_RING_CLASS} />
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
             <label htmlFor="config-schedule">Schedule (cron):</label>
-            <input id="config-schedule" type="text" value={tempSchedule} onChange={e => setTempSchedule(e.target.value)} style={{ padding: '0.5rem' }} />
+            <input id="config-schedule" type="text" value={tempSchedule} onChange={e => setTempSchedule(e.target.value)} className={FOCUS_RING_CLASS} style={{ padding: '0.5rem' }} />
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
             <label htmlFor="config-provider">Provider:</label>
-            <input id="config-provider" type="text" value={tempProvider} onChange={e => setTempProvider(e.target.value)} style={{ padding: '0.5rem' }} />
+            <input id="config-provider" type="text" value={tempProvider} onChange={e => setTempProvider(e.target.value)} className={FOCUS_RING_CLASS} style={{ padding: '0.5rem' }} />
           </div>
           <button onClick={saveDreamConfig} disabled={savingConfig} className={FOCUS_RING_CLASS} style={{ padding: '0.5rem 1rem' }}>
             {savingConfig ? 'Saving...' : 'Save Config'}

--- a/dashboard/src/components/DreamMemoryView.tsx
+++ b/dashboard/src/components/DreamMemoryView.tsx
@@ -275,6 +275,7 @@ export function DreamMemoryView() {
                 setEndDate('');
                 setPage(0);
               }}
+              className={FOCUS_RING_CLASS}
               style={{
                 background: 'rgba(255,255,255,0.1)',
                 border: 'none',

--- a/dashboard/src/components/DreamMemoryView.tsx
+++ b/dashboard/src/components/DreamMemoryView.tsx
@@ -310,6 +310,7 @@ export function DreamMemoryView() {
           <Settings size={18} style={{ marginRight: '0.5rem' }} /> Config
         </button>
         <button onClick={() => { setShowAll(!showAll); fetchMemories(searchQuery, 0, dreamConfig); }}
+          className={FOCUS_RING_CLASS}
           style={{
             padding: '0.75rem 1.25rem', borderRadius: '12px', border: showAll ? '1px solid var(--primary-neon)' : '1px solid rgba(255,255,255,0.1)',
             background: showAll ? 'rgba(0,240,255,0.1)' : 'rgba(255,255,255,0.05)', color: '#fff', fontWeight: 700, cursor: 'pointer'
@@ -333,10 +334,10 @@ export function DreamMemoryView() {
             <label htmlFor="config-provider">Provider:</label>
             <input id="config-provider" type="text" value={tempProvider} onChange={e => setTempProvider(e.target.value)} style={{ padding: '0.5rem' }} />
           </div>
-          <button onClick={saveDreamConfig} disabled={savingConfig} style={{ padding: '0.5rem 1rem' }}>
+          <button onClick={saveDreamConfig} disabled={savingConfig} className={FOCUS_RING_CLASS} style={{ padding: '0.5rem 1rem' }}>
             {savingConfig ? 'Saving...' : 'Save Config'}
           </button>
-          <button onClick={runDailyDreamsNow} disabled={savingConfig} style={{ padding: '0.5rem 1rem', background: 'var(--primary-neon)', color: '#000' }}>
+          <button onClick={runDailyDreamsNow} disabled={savingConfig} className={FOCUS_RING_CLASS} style={{ padding: '0.5rem 1rem', background: 'var(--primary-neon)', color: '#000' }}>
             Run Now
           </button>
         </div>
@@ -439,6 +440,7 @@ export function DreamMemoryView() {
       {/* Pagination */}
       <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '1rem', padding: '0.75rem 0', borderTop: '1px solid rgba(255,255,255,0.1)', flexShrink: 0 }}>
         <button onClick={() => goToPage(page - 1)} disabled={!hasPrev}
+          className={FOCUS_RING_CLASS}
           style={{
             padding: '0.5rem 1rem', borderRadius: '8px', border: '1px solid rgba(255,255,255,0.2)',
             background: hasPrev ? 'rgba(0,240,255,0.1)' : 'rgba(255,255,255,0.05)',
@@ -451,6 +453,7 @@ export function DreamMemoryView() {
           Page {page + 1}
         </span>
         <button onClick={() => goToPage(page + 1)} disabled={!hasNext}
+          className={FOCUS_RING_CLASS}
           style={{
             padding: '0.5rem 1rem', borderRadius: '8px', border: '1px solid rgba(255,255,255,0.2)',
             background: hasNext ? 'rgba(0,240,255,0.1)' : 'rgba(255,255,255,0.05)',

--- a/dashboard/src/components/DreamMemoryView.tsx
+++ b/dashboard/src/components/DreamMemoryView.tsx
@@ -284,8 +284,7 @@ export function DreamMemoryView() {
                 borderRadius: '8px',
                 cursor: 'pointer',
                 fontSize: '0.8rem',
-                fontWeight: 600,
-                outline: 'none'
+                fontWeight: 600
               }}
             >
               Clear
@@ -315,7 +314,7 @@ export function DreamMemoryView() {
           className={FOCUS_RING_CLASS}
           style={{
             padding: '0.75rem 1.25rem', borderRadius: '12px', border: showAll ? '1px solid var(--primary-neon)' : '1px solid rgba(255,255,255,0.1)',
-            background: showAll ? 'rgba(0,240,255,0.1)' : 'rgba(255,255,255,0.05)', color: '#fff', fontWeight: 700, cursor: 'pointer', outline: 'none'
+            background: showAll ? 'rgba(0,240,255,0.1)' : 'rgba(255,255,255,0.05)', color: '#fff', fontWeight: 700, cursor: 'pointer'
           }}>
           {showAll ? 'All Projects' : 'GolikeTool'}
         </button>
@@ -336,10 +335,10 @@ export function DreamMemoryView() {
             <label htmlFor="config-provider">Provider:</label>
             <input id="config-provider" type="text" value={tempProvider} onChange={e => setTempProvider(e.target.value)} style={{ padding: '0.5rem' }} />
           </div>
-          <button onClick={saveDreamConfig} disabled={savingConfig} className={FOCUS_RING_CLASS} style={{ padding: '0.5rem 1rem', outline: 'none' }}>
+          <button onClick={saveDreamConfig} disabled={savingConfig} className={FOCUS_RING_CLASS} style={{ padding: '0.5rem 1rem' }}>
             {savingConfig ? 'Saving...' : 'Save Config'}
           </button>
-          <button onClick={runDailyDreamsNow} disabled={savingConfig} className={FOCUS_RING_CLASS} style={{ padding: '0.5rem 1rem', background: 'var(--primary-neon)', color: '#000', outline: 'none' }}>
+          <button onClick={runDailyDreamsNow} disabled={savingConfig} className={FOCUS_RING_CLASS} style={{ padding: '0.5rem 1rem', background: 'var(--primary-neon)', color: '#000' }}>
             Run Now
           </button>
         </div>
@@ -447,7 +446,7 @@ export function DreamMemoryView() {
             padding: '0.5rem 1rem', borderRadius: '8px', border: '1px solid rgba(255,255,255,0.2)',
             background: hasPrev ? 'rgba(0,240,255,0.1)' : 'rgba(255,255,255,0.05)',
             color: hasPrev ? 'var(--primary-neon)' : 'var(--text-muted)',
-            cursor: hasPrev ? 'pointer' : 'default', fontWeight: 700, fontSize: '0.85rem', outline: 'none'
+            cursor: hasPrev ? 'pointer' : 'default', fontWeight: 700, fontSize: '0.85rem'
           }}>
           ← Prev
         </button>
@@ -460,7 +459,7 @@ export function DreamMemoryView() {
             padding: '0.5rem 1rem', borderRadius: '8px', border: '1px solid rgba(255,255,255,0.2)',
             background: hasNext ? 'rgba(0,240,255,0.1)' : 'rgba(255,255,255,0.05)',
             color: hasNext ? 'var(--primary-neon)' : 'var(--text-muted)',
-            cursor: hasNext ? 'pointer' : 'default', fontWeight: 700, fontSize: '0.85rem', outline: 'none'
+            cursor: hasNext ? 'pointer' : 'default', fontWeight: 700, fontSize: '0.85rem'
           }}>
           Next →
         </button>


### PR DESCRIPTION
### 💡 What
Added visible focus rings to multiple interactive elements (buttons) in the `DreamMemoryView` and `ControlCenterView` components.

### 🎯 Why
To improve keyboard navigation and overall accessibility. Previously, several buttons (like "Save Config", "Run Now", "Pagination Next", and "Create Access Token") did not have clear visual indicators when focused via keyboard navigation, making it difficult for users relying on keyboards to know which element was active.

### ♿ Accessibility
- Added `focus-visible:ring-2 focus-visible:ring-[var(--primary-neon)]` classes (via `FOCUS_RING_CLASS` constant) to buttons.
- This ensures standard, high-visibility focus states appear when navigating with the `Tab` key, without disrupting mouse interaction aesthetics.

---
*PR created automatically by Jules for task [3123216876092793535](https://jules.google.com/task/3123216876092793535) started by @giauphan*