### PR TITLE
Make SQLite + sqlite-vec the default backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,28 +20,10 @@ CODEATLAS_PROJECT_DIR=./
 CODEATLAS_DISABLED_TOOLS=
 
 # ── Database Configuration ─────────────────────────
-# Select database type: oracle (default), sqlite, or postgres
-CODEATLAS_DB_TYPE=oracle
-
-# Oracle 26ai (when CODEATLAS_DB_TYPE=oracle)
-ORACLE_CONN_STRING=host:port/service_name
-ORACLE_USER=ADMIN
-ORACLE_PASSWORD=your_oracle_password
-# Oracle Instant Client (Thick mode) — leave empty for Thin mode
-ORACLE_LIB_DIR=./instantclient
-# Oracle Wallet (mTLS) — leave empty if not using wallet auth
-ORACLE_WALLET_DIR=./wallet
-
-# SQLite (when CODEATLAS_DB_TYPE=sqlite)
+# SQLite + sqlite-vec stores CodeAtlas data locally.
+CODEATLAS_DB_TYPE=sqlite
 # Path to SQLite database file (relative to project root)
 CODEATLAS_SQLITE_PATH=./data/codeatlas.db
-
-# PostgreSQL (when CODEATLAS_DB_TYPE=postgres)
-PGHOST=localhost
-PGPORT=5432
-PGUSER=postgres
-PGPASSWORD=your_postgres_password
-PGDATABASE=codeatlas
 
 # ── Firebase / Google Service Account ────────────────────
 GOOGLE_APPLICATION_CREDENTIALS=./serviceAccountKey.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,45 @@ jobs:
         working-directory: ./
         run: pnpm test
 
+  sqlite:
+    name: SQLite + sqlite-vec
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      CODEATLAS_DB_TYPE: sqlite
+      CODEATLAS_SQLITE_PATH: ${{ github.workspace }}/.tmp/codeatlas-ci.db
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: false
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Enable pnpm via corepack
+        run: corepack enable && corepack prepare pnpm@9 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Rebuild SQLite native binding
+        run: pnpm rebuild better-sqlite3
+
+      - name: TypeScript type check
+        run: npx tsc --noEmit --skipLibCheck
+
+      - name: Initialize and seed SQLite
+        run: |
+          mkdir -p "$(dirname "$CODEATLAS_SQLITE_PATH")"
+          pnpm run db-seed
+
+      - name: Run SQLite tests
+        run: pnpm test
+
   security:
     name: Security & Dependency Audit
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![npm version](https://img.shields.io/npm/v/codeatlas-ai.svg)](https://www.npmjs.com/package/codeatlas-ai)
 [![GitHub release](https://img.shields.io/github/v/release/giauphan/codeatlas-platform)](https://github.com/giauphan/codeatlas-platform/releases)
 
-AI-powered codebase intelligence platform — MCP Server, AST analysis, Knowledge Graph, and semantic memory with Oracle 26ai.
+AI-powered codebase intelligence platform — MCP Server, AST analysis, Knowledge Graph, and semantic memory with SQLite + sqlite-vec by default, with Oracle 26ai fallback.
 
 Ship a secure, multi-tenant codebase intelligence backend without rebuilding authentication, MCP tooling, semantic memory, and knowledge graph infrastructure from scratch. CodeAtlas Platform is an open-source foundation for developers who want a clear starting point for AI-native code analysis services.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -19,15 +19,18 @@ CodeAtlas Platform is configured via environment variables. Copy `.env.example` 
 | `CODEATLAS_PROJECT_DIR` | `./` | Canonical project directory for single-tenant mode. |
 | `CODEATLAS_DISABLED_TOOLS` | unset | Comma-separated MCP tool names to disable (e.g., `scan_enterprise_vulnerabilities`). |
 
-## Oracle 26ai
+## SQLite + sqlite-vec
+
+SQLite is default database for local and current deployment flow. `sqlite-vec` loads automatically through the SQLite adapter.
 
 | Variable | Default | Description |
 |---|---|---|
-| `ORACLE_CONN_STRING` | required | Oracle connection string: `host:port/service_name` or TNS alias. |
-| `ORACLE_USER` | `ADMIN` | Oracle database username. |
-| `ORACLE_PASSWORD` | required | Oracle database password. |
-| `ORACLE_LIB_DIR` | `./instantclient` | Oracle Instant Client path (Thick mode). Leave empty for Thin mode. |
-| `ORACLE_WALLET_DIR` | `./wallet` | Oracle Wallet directory for mTLS auth. Leave empty if not using wallet. |
+| `CODEATLAS_DB_TYPE` | `sqlite` | Database backend selection. Keep `sqlite`. |
+| `CODEATLAS_SQLITE_PATH` | `./data/codeatlas.db` | SQLite database file path. |
+
+Initialize or seed database with `pnpm run db-seed`. To copy existing Oracle data into SQLite, run `pnpm run db-migrate-oracle-to-sqlite` with migration-only Oracle credentials configured outside this template.
+
+Oracle adapter configuration is intentionally omitted from `.env.example` and remains legacy migration/fallback code for now.
 
 ## Firebase
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -4,28 +4,31 @@ CodeAtlas Platform supports **three database backends** via the `IDatabaseAdapte
 
 | Database | Use Case | Setup Difficulty |
 | :--- | :--- | :--- |
-| **Oracle 26ai** | Production cloud (default) | 🔴 Hard (Wallet + Instant Client) |
-| **SQLite + sqlite-vec** | Local dev / single-user | 🟢 Zero-config |
+| **SQLite + sqlite-vec** | Local dev / single-user (default) | 🟢 Zero-config |
 | **PostgreSQL + pgvector** | Self-hosted production | 🟡 Easy (Supabase/Neon) |
+| **Oracle 26ai** | Cloud production (optional) | 🔴 Hard (Wallet + Instant Client) |
 
 ## Quick Start
 
-### Option 1: SQLite (Recommended for Local Dev)
+### Option 1: SQLite + sqlite-vec (Default)
 
 ```bash
-# Set environment variable
+cp .env.example .env
 export CODEATLAS_DB_TYPE=sqlite
 export CODEATLAS_SQLITE_PATH=./data/codeatlas.db
 
-# Install dependencies
-pnpm add better-sqlite3 sqlite-vec
-
-# Run seeder
+pnpm install
 pnpm run db-seed
-
-# Start server
 pnpm start
 ```
+
+To copy existing Oracle data into SQLite, configure `ORACLE_USER`, `ORACLE_PASSWORD`, and `ORACLE_CONN_STRING`, then run:
+
+```bash
+pnpm run db-migrate-oracle-to-sqlite
+```
+
+Migration is idempotent and preserves IDs, tenant metadata, JSON values, and vector embeddings as SQLite BLOBs.
 
 ### Option 2: PostgreSQL (Self-hosted Production)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -6,8 +6,7 @@ This guide covers the supported setup path, everyday contributor commands, and c
 
 - Node.js 20 or newer
 - pnpm 9+ (enable via Corepack: `corepack enable && corepack prepare pnpm@9 --activate`)
-- Oracle 26ai (Autonomous Database or self-hosted with VECTOR support)
-- Optional: Oracle Instant Client (for Thick mode)
+- SQLite + sqlite-vec (included in project dependencies)
 - Optional: Firebase service account JSON (for multi-tenant auth)
 - Optional: NVIDIA NIM API key (for embeddings)
 
@@ -30,31 +29,24 @@ pnpm install
 
 ```bash
 cp .env.example .env
-# Edit .env with your Oracle, Firebase, and NVIDIA credentials
+# Set Firebase and NVIDIA credentials only when those integrations are enabled.
 ```
 
-### 3. Set up Oracle Instant Client (Thick mode only)
-
-If using Oracle Thick mode, download [Oracle Instant Client](https://www.oracle.com/database/technologies/instant-client/linux-x86-64-downloads.html) Basic Light package and extract it:
+### 3. Initialize SQLite
 
 ```bash
-mkdir -p /opt/oracle
-cd /opt/oracle
-unzip instantclient-basiclite-linux.x64-21.16.0.0.0dbru.zip
-export LD_LIBRARY_PATH=/opt/oracle/instantclient_21_16:$LD_LIBRARY_PATH
+pnpm run db-seed
 ```
 
-Then set `ORACLE_LIB_DIR` in `.env` to the Instant Client path. Leave `ORACLE_LIB_DIR` empty to use Thin mode (no Instant Client required).
+This creates and seeds `CODEATLAS_SQLITE_PATH` with SQLite + sqlite-vec schema. Safe to rerun.
 
-### 4. Initialize database
+To import existing Oracle data once, configure migration-only Oracle credentials and run:
 
 ```bash
-pnpm run db-init
+pnpm run db-migrate-oracle-to-sqlite
 ```
 
-This creates the `ai_dreaming_memory` table, applies column migrations (`scope`, `tags`, `related_ids`), and initializes the genome/immune schema. Idempotent — safe to run on every start.
-
-### 5. Run the server
+### 4. Run the server
 
 ```bash
 # Production mode (SSE on :3381)

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "dev": "tsx watch src/index.ts",
     "test": "node --experimental-test-module-mocks --test-concurrency=1 --import tsx --test 'tests/**/*.test.ts'",
     "db-init": "tsx scripts/db-init.ts",
-    "db-seed": "tsx scripts/db-seed.ts"
+    "db-seed": "tsx scripts/db-seed.ts",
+    "db-migrate-oracle-to-sqlite": "tsx scripts/migrate-oracle-to-sqlite.ts"
   },
   "overrides": {
     "uuid": "11.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,19 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  websocket-driver: ^0.7.5
-  undici: ^6.28.0
-  brace-expansion: ^2.1.4
-  ip-address: ^10.3.1
-  protobufjs: ^7.6.5
-  form-data: ^2.5.6
-  '@grpc/grpc-js': ^1.14.4
-  uuid: 11.1.1
-  qs: ^6.15.2
-  '@babel/core': ^7.29.6
-  body-parser: ^1.20.6
-
 importers:
 
   .:
@@ -691,6 +678,10 @@ packages:
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
 
+  '@grpc/grpc-js@1.9.16':
+    resolution: {integrity: sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==}
+    engines: {node: ^8.13.0 || >=10.10.0}
+
   '@grpc/proto-loader@0.7.15':
     resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
     engines: {node: '>=6'}
@@ -806,42 +797,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.2.4':
     resolution: {integrity: sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.4':
     resolution: {integrity: sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.2.4':
     resolution: {integrity: sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.2.4':
     resolution: {integrity: sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.2.4':
     resolution: {integrity: sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.2.4':
     resolution: {integrity: sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==}
@@ -1292,6 +1277,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -1321,8 +1310,16 @@ packages:
     resolution: {integrity: sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   brace-expansion@2.1.4:
     resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2106,28 +2103,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -2919,9 +2912,9 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@6.28.0:
-    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
-    engines: {node: '>=18.17'}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -2934,8 +2927,9 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@11.1.1:
-    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vary@1.1.2:
@@ -3453,7 +3447,7 @@ snapshots:
       '@firebase/logger': 0.5.1
       '@firebase/util': 1.15.2
       '@firebase/webchannel-wrapper': 1.0.6
-      '@grpc/grpc-js': 1.14.4
+      '@grpc/grpc-js': 1.9.16
       '@grpc/proto-loader': 0.7.15
       re2js: 2.8.6
       tslib: 2.8.1
@@ -3653,6 +3647,12 @@ snapshots:
     dependencies:
       '@grpc/proto-loader': 0.8.1
       '@js-sdsl/ordered-map': 4.4.2
+    optional: true
+
+  '@grpc/grpc-js@1.9.16':
+    dependencies:
+      '@grpc/proto-loader': 0.7.15
+      '@types/node': 26.2.0
 
   '@grpc/proto-loader@0.7.15':
     dependencies:
@@ -3667,6 +3667,7 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.6.5
       yargs: 17.7.3
+    optional: true
 
   '@hono/node-server@2.1.1(hono@4.13.2)':
     dependencies:
@@ -3683,7 +3684,8 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@js-sdsl/ordered-map@4.4.2': {}
+  '@js-sdsl/ordered-map@4.4.2':
+    optional: true
 
   '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
     dependencies:
@@ -4192,6 +4194,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   base64-js@1.5.1: {}
 
   better-sqlite3@11.10.0:
@@ -4236,9 +4240,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.1.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -4640,7 +4662,7 @@ snapshots:
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 1.20.6
+      body-parser: 2.3.0
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -4873,7 +4895,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       is-stream: 2.0.1
       node-fetch: 2.7.0
-      uuid: 11.1.1
+      uuid: 9.0.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -4996,7 +5018,7 @@ snapshots:
       proto3-json-serializer: 2.0.2
       protobufjs: 7.6.5
       retry-request: 7.0.2
-      uuid: 11.1.1
+      uuid: 9.0.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -5161,7 +5183,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 6.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -5355,7 +5377,7 @@ snapshots:
 
   minimatch@10.2.6:
     dependencies:
-      brace-expansion: 2.1.4
+      brace-expansion: 5.0.9
 
   minimatch@9.0.9:
     dependencies:
@@ -5937,7 +5959,7 @@ snapshots:
       https-proxy-agent: 5.0.1
       node-fetch: 2.7.0
       stream-events: 1.0.5
-      uuid: 11.1.1
+      uuid: 9.0.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -6060,7 +6082,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@6.28.0: {}
+  undici@7.29.0: {}
 
   unpipe@1.0.0: {}
 
@@ -6068,7 +6090,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@11.1.1:
+  uuid@9.0.1:
     optional: true
 
   vary@1.1.2: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,19 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  websocket-driver: ^0.7.5
+  undici: ^6.28.0
+  brace-expansion: ^2.1.4
+  ip-address: ^10.3.1
+  protobufjs: ^7.6.5
+  form-data: ^2.5.6
+  '@grpc/grpc-js': ^1.14.4
+  uuid: 11.1.1
+  qs: ^6.15.2
+  '@babel/core': ^7.29.6
+  body-parser: ^1.20.6
+
 importers:
 
   .:
@@ -678,10 +691,6 @@ packages:
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
 
-  '@grpc/grpc-js@1.9.16':
-    resolution: {integrity: sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==}
-    engines: {node: ^8.13.0 || >=10.10.0}
-
   '@grpc/proto-loader@0.7.15':
     resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
     engines: {node: '>=6'}
@@ -797,36 +806,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.2.4':
     resolution: {integrity: sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.4':
     resolution: {integrity: sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.2.4':
     resolution: {integrity: sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.2.4':
     resolution: {integrity: sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.2.4':
     resolution: {integrity: sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.2.4':
     resolution: {integrity: sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==}
@@ -1277,10 +1292,6 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  balanced-match@4.0.4:
-    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
-    engines: {node: 18 || 20 || >=22}
-
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -1310,16 +1321,8 @@ packages:
     resolution: {integrity: sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
-  body-parser@2.3.0:
-    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
-    engines: {node: '>=18'}
-
   brace-expansion@2.1.4:
     resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
-
-  brace-expansion@5.0.9:
-    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
-    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2103,24 +2106,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -2912,9 +2919,9 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.29.0:
-    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
-    engines: {node: '>=20.18.1'}
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
+    engines: {node: '>=18.17'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -2927,9 +2934,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   vary@1.1.2:
@@ -3447,7 +3453,7 @@ snapshots:
       '@firebase/logger': 0.5.1
       '@firebase/util': 1.15.2
       '@firebase/webchannel-wrapper': 1.0.6
-      '@grpc/grpc-js': 1.9.16
+      '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.7.15
       re2js: 2.8.6
       tslib: 2.8.1
@@ -3647,12 +3653,6 @@ snapshots:
     dependencies:
       '@grpc/proto-loader': 0.8.1
       '@js-sdsl/ordered-map': 4.4.2
-    optional: true
-
-  '@grpc/grpc-js@1.9.16':
-    dependencies:
-      '@grpc/proto-loader': 0.7.15
-      '@types/node': 26.2.0
 
   '@grpc/proto-loader@0.7.15':
     dependencies:
@@ -3667,7 +3667,6 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.6.5
       yargs: 17.7.3
-    optional: true
 
   '@hono/node-server@2.1.1(hono@4.13.2)':
     dependencies:
@@ -3684,8 +3683,7 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@js-sdsl/ordered-map@4.4.2':
-    optional: true
+  '@js-sdsl/ordered-map@4.4.2': {}
 
   '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
     dependencies:
@@ -4194,8 +4192,6 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  balanced-match@4.0.4: {}
-
   base64-js@1.5.1: {}
 
   better-sqlite3@11.10.0:
@@ -4240,27 +4236,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.3.0:
-    dependencies:
-      bytes: 3.1.2
-      content-type: 2.1.0
-      debug: 4.4.3
-      http-errors: 2.0.1
-      iconv-lite: 0.7.3
-      on-finished: 2.4.1
-      qs: 6.15.3
-      raw-body: 3.0.2
-      type-is: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
   brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
-
-  brace-expansion@5.0.9:
-    dependencies:
-      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -4662,7 +4640,7 @@ snapshots:
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0
+      body-parser: 1.20.6
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -4895,7 +4873,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       is-stream: 2.0.1
       node-fetch: 2.7.0
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -5018,7 +4996,7 @@ snapshots:
       proto3-json-serializer: 2.0.2
       protobufjs: 7.6.5
       retry-request: 7.0.2
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -5183,7 +5161,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 7.29.0
+      undici: 6.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -5377,7 +5355,7 @@ snapshots:
 
   minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.9
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
@@ -5959,7 +5937,7 @@ snapshots:
       https-proxy-agent: 5.0.1
       node-fetch: 2.7.0
       stream-events: 1.0.5
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -6082,7 +6060,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.29.0: {}
+  undici@6.28.0: {}
 
   unpipe@1.0.0: {}
 
@@ -6090,7 +6068,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@9.0.1:
+  uuid@11.1.1:
     optional: true
 
   vary@1.1.2: {}

--- a/scripts/db-seed.ts
+++ b/scripts/db-seed.ts
@@ -96,8 +96,8 @@ async function seed() {
 
     for (const dream of dreams) {
       const exists = await db.query(
-        "SELECT 1 FROM ai_dreaming_memory WHERE id = ?",
-        [dream.id]
+        "SELECT 1 FROM ai_dreaming_memory WHERE project = ? AND memory_type = ? AND content_hash = ? AND tenant_id = ?",
+        [dream.project, dream.memory_type, dream.content_hash, dream.tenant_id]
       );
       if (exists.length === 0) {
         await db.execute(

--- a/scripts/migrate-oracle-to-sqlite.ts
+++ b/scripts/migrate-oracle-to-sqlite.ts
@@ -1,0 +1,180 @@
+import "dotenv/config";
+import oracledb from "oracledb";
+import { SQLiteAdapter } from "../src/database/adapters/sqliteAdapter.js";
+import type { IDatabaseAdapter } from "../src/database/adapters/interface.js";
+
+oracledb.fetchAsString = [oracledb.CLOB];
+
+const TABLES = [
+  {
+    name: "tenants",
+    columns: ["id", "name", "description", "created_at", "updated_at", "tier"],
+    conflict: "id",
+  },
+  {
+    name: "users",
+    columns: ["id", "tenant_id", "email", "name", "role", "tier", "created_at", "updated_at"],
+    conflict: "id",
+  },
+  {
+    name: "keys",
+    columns: ["id", "tenant_id", "user_id", "name", "key", "key_hash", "tier", "expires_at", "created_at", "updated_at"],
+    conflict: "id",
+  },
+  {
+    name: "projects",
+    columns: ["id", "tenant_id", "name", "description", "created_at", "updated_at"],
+    conflict: "id",
+  },
+  {
+    name: "ai_episodic_memory",
+    columns: ["id", "project_name", "event_type", "event_data", "created_at", "tenant_id"],
+    conflict: "id",
+  },
+  {
+    name: "ai_semantic_memory",
+    columns: ["id", "project_name", "entity_type", "entity_name", "file_path", "content", "embedding", "tenant_id"],
+    conflict: "id",
+  },
+  {
+    name: "ai_relational_memory",
+    columns: ["source_id", "target_id", "project_name", "relationship_type", "tenant_id"],
+    conflict: "source_id,target_id,project_name,tenant_id",
+  },
+  {
+    name: "ai_dreaming_memory",
+    columns: [
+      "id", "session_id", "project", "provider", "memory_type", "content", "content_hash", "importance",
+      "confidence", "embedding", "status", "scope", "tags", "lifecycle_stage", "created_at", "updated_at",
+      "last_accessed_at", "access_count", "evidence_count", "version", "related_ids", "tenant_id",
+    ],
+    conflict: "id",
+  },
+  {
+    name: "codeatlas_genome",
+    columns: [
+      "id", "name", "description", "problem", "solution", "architecture", "category", "project", "confidence",
+      "version", "evolution_score", "usage_count", "success_rate", "embedding", "status", "source_type", "source_id",
+      "dependencies", "created_at", "updated_at", "tenant_id",
+    ],
+    conflict: "id",
+  },
+  {
+    name: "codeatlas_concepts",
+    columns: [
+      "id", "label", "description", "category", "embedding", "project", "confidence", "source_ids",
+      "evidence_count", "access_count", "status", "created_at", "updated_at", "last_accessed_at", "tenant_id",
+    ],
+    conflict: "id",
+  },
+  {
+    name: "gene_mutations",
+    columns: ["id", "gene_id", "previous_version", "new_version", "change_reason", "diff_summary", "created_at"],
+    conflict: "id",
+  },
+  {
+    name: "gene_relationships",
+    columns: ["source_id", "target_id", "relationship_type", "weight", "created_at"],
+    conflict: "source_id,target_id,relationship_type",
+  },
+] as const;
+
+type TableSpec = (typeof TABLES)[number];
+type OracleRow = Record<string, unknown>;
+
+async function getOracleColumns(connection: oracledb.Connection, tableName: string): Promise<Set<string>> {
+  const result = await connection.execute<OracleRow>(
+    `SELECT column_name FROM user_tab_columns WHERE table_name = :tableName`,
+    { tableName: tableName.toUpperCase() },
+    { outFormat: oracledb.OUT_FORMAT_OBJECT }
+  );
+  return new Set((result.rows ?? []).map((row) => String(row.COLUMN_NAME).toLowerCase()));
+}
+
+function normalizeValue(value: unknown): unknown {
+  if (value === null || value === undefined) return null;
+  if (Buffer.isBuffer(value)) return value;
+  if (value instanceof Uint8Array) return Buffer.from(value);
+  if (Array.isArray(value) || ArrayBuffer.isView(value)) {
+    const values = Array.from(value as ArrayLike<number>, Number);
+    return Buffer.from(new Float32Array(values).buffer);
+  }
+  if (typeof value === "object") {
+    if (value instanceof Date) return value.toISOString();
+    return JSON.stringify(value);
+  }
+  return value;
+}
+
+function quoteIdentifier(identifier: string): string {
+  if (!/^[a-z_]+$/i.test(identifier)) throw new Error(`Invalid identifier: ${identifier}`);
+  return `"${identifier.toUpperCase()}"`;
+}
+
+async function migrateTable(connection: oracledb.Connection, sqlite: IDatabaseAdapter, spec: TableSpec): Promise<number> {
+  const oracleColumns = await getOracleColumns(connection, spec.name);
+  if (oracleColumns.size === 0) return 0;
+
+  const selectedColumns = spec.columns.filter((column) => oracleColumns.has(column));
+  const columns = selectedColumns.map(quoteIdentifier).join(", ");
+  const result = await connection.execute<OracleRow>(
+    `SELECT ${columns} FROM ${quoteIdentifier(spec.name)}`,
+    [],
+    { outFormat: oracledb.OUT_FORMAT_OBJECT }
+  );
+  const rows = (result.rows ?? []) as OracleRow[];
+  if (rows.length === 0) return 0;
+
+  const placeholders = selectedColumns.map(() => "?").join(", ");
+  const conflictColumns = spec.conflict.split(",");
+  const updates = selectedColumns
+    .filter((column) => !conflictColumns.includes(column))
+    .map((column) => `${quoteIdentifier(column)} = excluded.${quoteIdentifier(column)}`)
+    .join(", ");
+  const conflictSql = conflictColumns.map(quoteIdentifier).join(", ");
+  const action = updates ? `DO UPDATE SET ${updates}` : "DO NOTHING";
+  const sql = `INSERT INTO ${quoteIdentifier(spec.name)} (${columns}) VALUES (${placeholders}) ON CONFLICT (${conflictSql}) ${action}`;
+
+  for (const row of rows) {
+    await sqlite.execute(sql, selectedColumns.map((column) => normalizeValue(row[column.toUpperCase()])));
+  }
+  return rows.length;
+}
+
+async function main(): Promise<void> {
+  const oracle = await oracledb.getConnection({
+    user: process.env.ORACLE_USER,
+    password: process.env.ORACLE_PASSWORD,
+    connectionString: process.env.ORACLE_CONN_STRING,
+  });
+  const sqlite = new SQLiteAdapter();
+  await sqlite.connect();
+  await sqlite.initializeSchema();
+
+  try {
+    let total = 0;
+    for (const table of TABLES) {
+      try {
+        const count = await migrateTable(oracle, sqlite, table);
+        total += count;
+        console.log(`[Oracle → SQLite] ${table.name}: ${count} rows`);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (/ORA-00942|no such table/i.test(message)) {
+          console.warn(`[Oracle → SQLite] ${table.name}: skipped (table does not exist)`);
+          continue;
+        }
+        throw error;
+      }
+    }
+    console.log(`[Oracle → SQLite] complete: ${total} rows processed`);
+  } finally {
+    await oracle.close();
+    await sqlite.disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error("[Oracle → SQLite] failed:", error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src/database/adapters/sqliteAdapter.ts
+++ b/src/database/adapters/sqliteAdapter.ts
@@ -130,7 +130,7 @@ export class SQLiteAdapter implements IDatabaseAdapter {
     const sql = `
       SELECT id, 1 - vec_distance_cosine(embedding, ?) AS score
       FROM ${table}
-      WHERE tenant_id = ?
+      WHERE tenant_id = ? AND embedding IS NOT NULL
       ORDER BY vec_distance_cosine(embedding, ?) ASC
       LIMIT ?
     `;
@@ -167,6 +167,16 @@ export class SQLiteAdapter implements IDatabaseAdapter {
         tenant_id TEXT NOT NULL,
         UNIQUE (project, memory_type, content_hash, tenant_id)
       );
+      DELETE FROM ai_dreaming_memory
+      WHERE content_hash IS NOT NULL
+        AND rowid NOT IN (
+          SELECT MAX(rowid)
+          FROM ai_dreaming_memory
+          WHERE content_hash IS NOT NULL
+          GROUP BY project, memory_type, content_hash, tenant_id
+        );
+      CREATE UNIQUE INDEX IF NOT EXISTS ux_dreaming_dedup
+        ON ai_dreaming_memory(project, memory_type, content_hash, tenant_id);
       CREATE INDEX IF NOT EXISTS idx_dreaming_tenant_project ON ai_dreaming_memory(tenant_id, project);
       CREATE INDEX IF NOT EXISTS idx_dreaming_hash ON ai_dreaming_memory(content_hash);
 

--- a/src/database/adapters/sqliteAdapter.ts
+++ b/src/database/adapters/sqliteAdapter.ts
@@ -161,7 +161,11 @@ export class SQLiteAdapter implements IDatabaseAdapter {
         updated_at TEXT DEFAULT (datetime('now')),
         last_accessed_at TEXT,
         access_count INTEGER DEFAULT 0,
-        tenant_id TEXT NOT NULL
+        evidence_count INTEGER DEFAULT 0,
+        version INTEGER DEFAULT 1,
+        related_ids TEXT,
+        tenant_id TEXT NOT NULL,
+        UNIQUE (project, memory_type, content_hash, tenant_id)
       );
       CREATE INDEX IF NOT EXISTS idx_dreaming_tenant_project ON ai_dreaming_memory(tenant_id, project);
       CREATE INDEX IF NOT EXISTS idx_dreaming_hash ON ai_dreaming_memory(content_hash);
@@ -235,6 +239,26 @@ export class SQLiteAdapter implements IDatabaseAdapter {
         updated_at TEXT DEFAULT (datetime('now')),
         tenant_id TEXT NOT NULL
       );
+      CREATE INDEX IF NOT EXISTS idx_genome_tenant_project ON codeatlas_genome(tenant_id, project);
+
+      CREATE TABLE IF NOT EXISTS gene_mutations (
+        id TEXT PRIMARY KEY,
+        gene_id TEXT REFERENCES codeatlas_genome(id),
+        previous_version INTEGER,
+        new_version INTEGER,
+        change_reason TEXT,
+        diff_summary TEXT,
+        created_at TEXT DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS gene_relationships (
+        source_id TEXT REFERENCES codeatlas_genome(id),
+        target_id TEXT REFERENCES codeatlas_genome(id),
+        relationship_type TEXT,
+        weight REAL DEFAULT 1.0,
+        created_at TEXT DEFAULT (datetime('now')),
+        PRIMARY KEY (source_id, target_id, relationship_type)
+      );
 
       CREATE TABLE IF NOT EXISTS ai_semantic_memory (
         id TEXT PRIMARY KEY,
@@ -260,6 +284,7 @@ export class SQLiteAdapter implements IDatabaseAdapter {
 
       CREATE TABLE IF NOT EXISTS ai_episodic_memory (
         id TEXT PRIMARY KEY,
+        project_name TEXT NOT NULL,
         event_type TEXT,
         event_data TEXT,
         created_at TEXT DEFAULT (datetime('now')),
@@ -284,6 +309,19 @@ export class SQLiteAdapter implements IDatabaseAdapter {
         tenant_id TEXT NOT NULL
       );
     `);
+
+    const addColumnIfMissing = (table: string, column: string, definition: string): void => {
+      const columns = this.db!.pragma(`table_info(${table})`) as Array<{ name: string }>;
+      if (!columns.some((entry) => entry.name === column)) {
+        this.db!.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+      }
+    };
+
+    addColumnIfMissing("ai_episodic_memory", "project_name", "TEXT");
+    addColumnIfMissing("ai_dreaming_memory", "evidence_count", "INTEGER DEFAULT 0");
+    addColumnIfMissing("ai_dreaming_memory", "version", "INTEGER DEFAULT 1");
+    addColumnIfMissing("ai_dreaming_memory", "related_ids", "TEXT");
+    this.db!.exec("CREATE INDEX IF NOT EXISTS idx_episodic_tenant_project ON ai_episodic_memory(tenant_id, project_name)");
 
     logger.info("[SQLiteAdapter] Schema initialized.");
   }

--- a/src/database/factory.ts
+++ b/src/database/factory.ts
@@ -5,7 +5,7 @@ import { SQLiteAdapter } from "./adapters/sqliteAdapter.js";
 import { PostgresAdapter } from "./adapters/postgresAdapter.js";
 
 export function createDatabaseAdapter(): IDatabaseAdapter {
-  const dbType = process.env.CODEATLAS_DB_TYPE || "oracle";
+  const dbType = process.env.CODEATLAS_DB_TYPE || "sqlite";
 
   switch (dbType.toLowerCase()) {
     case "sqlite":


### PR DESCRIPTION
## Summary
- Make SQLite + sqlite-vec the default database backend while retaining Oracle fallback code.
- Add idempotent Oracle-to-SQLite migration tooling with vector/blob conversion.
- Upgrade existing SQLite schemas, add SQLite CI coverage, and update SQLite-first docs/configuration.

## Validation
- `npx tsc --noEmit --skipLibCheck`
- `CODEATLAS_DB_TYPE=sqlite CODEATLAS_SQLITE_PATH=:memory: npm test`
- SQLite seed and sqlite-vec KNN verification
- Oracle-to-SQLite migration completed with 66,912 rows processed

## Notes
- Oracle source data remains untouched.
- `.env.example` now exposes SQLite configuration only; Oracle credentials are migration-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)