### PR TITLE
⚡ Bolt: [performance improvement] Optimize cosine similarity inner loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,7 @@
 ## 2026-08-19 - Pre-parsing vectors to avoid O(N^2) inner-loop allocations
 **Learning:** When calculating vector similarities or comparisons in $O(N^2)$ nested loops, repeatedly extracting properties (`getVal`) and parsing raw string/arrays into `Float32Array` within the inner loop causes massive, redundant CPU cycles and garbage collection pressure in V8.
 **Action:** When calculating similarity matrix distances or comparisons, pre-parse data structures (like converting raw arrays to `Float32Array`) and extract invariant lookups during an $O(N)$ preprocessing phase, mapping the valid subset to an array of objects to iterate over, effectively eliminating redundant type coercion in the inner loop.
+
+## 2026-08-21 - Extract array elements from loop in O(N^2) math operations
+**Learning:** When executing mathematical loops inside O(N^2) pairwise comparisons, array elements are looked up multiple times. In modern JavaScript/TypeScript (V8), looking up elements by index in a hot loop can slightly inflate bytecode and hinder execution.
+**Action:** Optimize hot loops by caching array lengths to local variables and extracting array elements to local variables inside the loop to avoid multiple lookups (`const vA = vecA[i]`).

--- a/src/services/consolidationEngine.ts
+++ b/src/services/consolidationEngine.ts
@@ -531,11 +531,15 @@ export class ConsolidationEngine {
     let dot = 0;
     let normA = 0;
     let normB = 0;
+    const len = vecA.length;
 
-    for (let i = 0; i < vecA.length; i++) {
-      dot += vecA[i] * vecB[i];
-      normA += vecA[i] * vecA[i];
-      normB += vecB[i] * vecB[i];
+    // ⚡ Bolt: Cache array lengths and extract array elements to local variables inside the loop to avoid multiple lookups
+    for (let i = 0; i < len; i++) {
+      const vA = vecA[i];
+      const vB = vecB[i];
+      dot += vA * vB;
+      normA += vA * vA;
+      normB += vB * vB;
     }
 
     const denom = Math.sqrt(normA) * Math.sqrt(normB);


### PR DESCRIPTION
**💡 What**
Optimized the `cosineSimilarity` mathematical loop in `src/services/consolidationEngine.ts` by explicitly caching `vecA.length` into a local variable before the loop, and extracting `vecA[i]` and `vecB[i]` into local variables inside the inner N loop.

**🎯 Why**
The `cosineSimilarity` function is called inside heavily nested $O(N^2)$ loops during AI dream deduplication and superseding. Redundant property accesses (`vecA.length` and array indexing lookups) in these hot loops cause unnecessary overhead and CPU work in V8. Explicitly hoisting these to local variables reduces the number of indexing operations per iteration from 6 to 2, minimizing CPU cycles and improving execution speed. 

**📊 Impact**
Slightly faster execution times for N^2 dream similarity matrix distance computations, especially as the number of elements being clustered scales up. This micro-optimization strictly avoids massive architectural shifts while reducing runtime execution overhead.

**🔬 Measurement**
Run `pnpm run build` to verify type checking and `pnpm test` to ensure regressions are not introduced. The tests for Clean Architecture Repositories (or the `ConsolidationEngine` directly) will run normally, maintaining exact behavior.

---
*PR created automatically by Jules for task [15636991865080831694](https://jules.google.com/task/15636991865080831694) started by @giauphan*