### PR TITLE
🎨 Palette: Add proper ARIA tab roles and focus rings to DocumentationView

### DIFF
--- a/dashboard/src/components/DocumentationView.tsx
+++ b/dashboard/src/components/DocumentationView.tsx
@@ -141,9 +141,30 @@ export const DocumentationView: React.FC = () => {
           { id: 'mcp', label: 'MCP Editor Config', icon: Settings },
           { id: 'architecture', label: 'Architecture', icon: Layers },
           { id: 'graph', label: 'Interactive Guide', icon: HelpCircle },
-        ].map((tab) => {
+        ].map((tab, index, array) => {
           const Icon = tab.icon;
           const isActive = activeSubTab === tab.id;
+
+          const handleKeyDown = (e: React.KeyboardEvent) => {
+            let nextIndex = -1;
+            if (e.key === 'ArrowRight') {
+              nextIndex = (index + 1) % array.length;
+            } else if (e.key === 'ArrowLeft') {
+              nextIndex = (index - 1 + array.length) % array.length;
+            } else if (e.key === 'Home') {
+              nextIndex = 0;
+            } else if (e.key === 'End') {
+              nextIndex = array.length - 1;
+            }
+
+            if (nextIndex !== -1) {
+              e.preventDefault();
+              setActiveSubTab(array[nextIndex].id as any);
+              const nextTab = document.getElementById(`tab-${array[nextIndex].id}`);
+              if (nextTab) nextTab.focus();
+            }
+          };
+
           return (
             <button
               key={tab.id}
@@ -151,7 +172,9 @@ export const DocumentationView: React.FC = () => {
               aria-selected={isActive}
               aria-controls={`panel-${tab.id}`}
               id={`tab-${tab.id}`}
+              tabIndex={isActive ? 0 : -1}
               onClick={() => setActiveSubTab(tab.id as any)}
+              onKeyDown={handleKeyDown}
               className={FOCUS_RING_CLASS}
               style={{
                 background: 'transparent',

--- a/dashboard/src/components/DocumentationView.tsx
+++ b/dashboard/src/components/DocumentationView.tsx
@@ -159,7 +159,7 @@ export const DocumentationView: React.FC = () => {
 
             if (nextIndex !== -1) {
               e.preventDefault();
-              setActiveSubTab(array[nextIndex].id as any);
+              setActiveSubTab(array[nextIndex].id as 'mcp' | 'architecture' | 'graph');
               const nextTab = document.getElementById(`tab-${array[nextIndex].id}`);
               if (nextTab) nextTab.focus();
             }
@@ -173,7 +173,7 @@ export const DocumentationView: React.FC = () => {
               aria-controls={`panel-${tab.id}`}
               id={`tab-${tab.id}`}
               tabIndex={isActive ? 0 : -1}
-              onClick={() => setActiveSubTab(tab.id as any)}
+              onClick={() => setActiveSubTab(tab.id as 'mcp' | 'architecture' | 'graph')}
               onKeyDown={handleKeyDown}
               className={FOCUS_RING_CLASS}
               style={{

--- a/dashboard/src/components/DocumentationView.tsx
+++ b/dashboard/src/components/DocumentationView.tsx
@@ -14,8 +14,10 @@ import {
 } from 'lucide-react';
 import { FOCUS_RING_CLASS } from '../lib/constants';
 
+type TabType = 'mcp' | 'architecture' | 'graph';
+
 export const DocumentationView: React.FC = () => {
-  const [activeSubTab, setActiveSubTab] = useState<'mcp' | 'architecture' | 'graph'>('mcp');
+  const [activeSubTab, setActiveSubTab] = useState<TabType>('mcp');
   const [copiedText, setCopiedText] = useState<string | null>(null);
 
   const backendUrl = window.location.origin.includes('localhost:5173')
@@ -159,7 +161,7 @@ export const DocumentationView: React.FC = () => {
 
             if (nextIndex !== -1) {
               e.preventDefault();
-              setActiveSubTab(array[nextIndex].id as 'mcp' | 'architecture' | 'graph');
+              setActiveSubTab(array[nextIndex].id as TabType);
               const nextTab = document.getElementById(`tab-${array[nextIndex].id}`);
               if (nextTab) nextTab.focus();
             }
@@ -173,7 +175,7 @@ export const DocumentationView: React.FC = () => {
               aria-controls={`panel-${tab.id}`}
               id={`tab-${tab.id}`}
               tabIndex={isActive ? 0 : -1}
-              onClick={() => setActiveSubTab(tab.id as 'mcp' | 'architecture' | 'graph')}
+              onClick={() => setActiveSubTab(tab.id as TabType)}
               onKeyDown={handleKeyDown}
               className={FOCUS_RING_CLASS}
               style={{

--- a/dashboard/src/components/DocumentationView.tsx
+++ b/dashboard/src/components/DocumentationView.tsx
@@ -12,6 +12,7 @@ import {
   Code,
   Sparkles
 } from 'lucide-react';
+import { FOCUS_RING_CLASS } from '../lib/constants';
 
 export const DocumentationView: React.FC = () => {
   const [activeSubTab, setActiveSubTab] = useState<'mcp' | 'architecture' | 'graph'>('mcp');
@@ -48,7 +49,7 @@ export const DocumentationView: React.FC = () => {
         fontWeight: 600,
         transition: 'all 0.2s ease',
       }}
-      className="copy-btn-hover"
+      className={`copy-btn-hover ${FOCUS_RING_CLASS}`}
     >
       {copiedText === id ? (
         <>
@@ -105,7 +106,7 @@ export const DocumentationView: React.FC = () => {
               textDecoration: 'none',
               transition: 'all 0.2s ease',
             }}
-            className="docs-btn-hover"
+            className={`docs-btn-hover ${FOCUS_RING_CLASS}`}
           >
             <BookOpen size={18} /> Quick Setup Guide <ExternalLink size={14} />
           </a>
@@ -127,7 +128,7 @@ export const DocumentationView: React.FC = () => {
               textDecoration: 'none',
               transition: 'all 0.2s ease',
             }}
-            className="docs-btn-hover"
+            className={`docs-btn-hover ${FOCUS_RING_CLASS}`}
           >
             <BookOpen size={18} /> AI Memory Guide <ExternalLink size={14} />
           </a>
@@ -135,7 +136,7 @@ export const DocumentationView: React.FC = () => {
       </div>
 
       {/* TABS SELECTOR */}
-      <div style={{ display: 'flex', borderBottom: '1px solid rgba(255,255,255,0.05)', paddingBottom: '2px', gap: '2rem' }}>
+      <div role="tablist" aria-label="Documentation sections" style={{ display: 'flex', borderBottom: '1px solid rgba(255,255,255,0.05)', paddingBottom: '2px', gap: '2rem' }}>
         {[
           { id: 'mcp', label: 'MCP Editor Config', icon: Settings },
           { id: 'architecture', label: 'Architecture', icon: Layers },
@@ -146,7 +147,12 @@ export const DocumentationView: React.FC = () => {
           return (
             <button
               key={tab.id}
+              role="tab"
+              aria-selected={isActive}
+              aria-controls={`panel-${tab.id}`}
+              id={`tab-${tab.id}`}
               onClick={() => setActiveSubTab(tab.id as any)}
+              className={FOCUS_RING_CLASS}
               style={{
                 background: 'transparent',
                 border: 'none',
@@ -174,7 +180,7 @@ export const DocumentationView: React.FC = () => {
       <div style={{ background: 'rgba(13, 17, 23, 0.45)', border: '1px solid rgba(255,255,255,0.05)', borderRadius: '24px', padding: '2.5rem', minHeight: '400px' }}>
         
         {activeSubTab === 'architecture' && (
-          <motion.div initial={{ opacity: 0, y: 5 }} animate={{ opacity: 1, y: 0 }} style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+          <motion.div role="tabpanel" id="panel-architecture" aria-labelledby="tab-architecture" initial={{ opacity: 0, y: 5 }} animate={{ opacity: 1, y: 0 }} style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
             <div>
               <h2 style={{ fontSize: '1.5rem', fontWeight: 800, color: '#fff', marginBottom: '0.75rem' }}>CodeAtlas Tri-Layer Memory</h2>
               <p style={{ color: 'var(--text-muted)', lineHeight: '1.6', marginBottom: '2rem' }}>
@@ -216,7 +222,7 @@ export const DocumentationView: React.FC = () => {
         )}
 
         {activeSubTab === 'mcp' && (
-          <motion.div initial={{ opacity: 0, y: 5 }} animate={{ opacity: 1, y: 0 }} style={{ display: 'flex', flexDirection: 'column', gap: '2.5rem' }}>
+          <motion.div role="tabpanel" id="panel-mcp" aria-labelledby="tab-mcp" initial={{ opacity: 0, y: 5 }} animate={{ opacity: 1, y: 0 }} style={{ display: 'flex', flexDirection: 'column', gap: '2.5rem' }}>
             <div>
               <h2 style={{ fontSize: '1.5rem', fontWeight: 800, color: '#fff', marginBottom: '0.5rem' }}>MCP Server Configuration</h2>
               <p style={{ color: 'var(--text-muted)', lineHeight: '1.5', marginBottom: '1.5rem' }}>
@@ -419,7 +425,7 @@ Use the CodeAtlas MCP tools to query or search relationships, dependencies, and 
         )}
 
         {activeSubTab === 'graph' && (
-          <motion.div initial={{ opacity: 0, y: 5 }} animate={{ opacity: 1, y: 0 }} style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+          <motion.div role="tabpanel" id="panel-graph" aria-labelledby="tab-graph" initial={{ opacity: 0, y: 5 }} animate={{ opacity: 1, y: 0 }} style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
             <div>
               <h2 style={{ fontSize: '1.5rem', fontWeight: 800, color: '#fff', marginBottom: '0.75rem' }}>Interactive Canvas Manual</h2>
               <p style={{ color: 'var(--text-muted)', lineHeight: '1.6', marginBottom: '1.5rem' }}>


### PR DESCRIPTION
**💡 What:**
Added standard ARIA tab roles (`role="tablist"`, `role="tab"`, `role="tabpanel"`) and linking properties (`aria-controls`, `aria-labelledby`) to the navigation tabs in the `DocumentationView`. Also applied the `FOCUS_RING_CLASS` to the tab buttons, copy buttons, and external links.

**🎯 Why:**
The documentation tabs were built with `button` elements that lacked structural context for screen readers to understand they were navigating sub-panels. Additionally, several interactive elements (like the copy buttons and external links) lacked the standard visible focus ring, making keyboard navigation difficult and inaccessible.

**📸 Before/After:**
*(See attached automated verification screenshot)*

**♿ Accessibility:**
- Proper tab hierarchy makes screen reader navigation intuitive.
- Visible focus rings ensure keyboard-only users can clearly see which element they are interacting with.

---
*PR created automatically by Jules for task [9065784522562670857](https://jules.google.com/task/9065784522562670857) started by @giauphan*