### PR TITLE
🎨 Palette: Add clear search button to Dream Memory view

### DIFF
--- a/dashboard/src/components/DreamMemoryView.tsx
+++ b/dashboard/src/components/DreamMemoryView.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Brain, Search, Trash2, AlertCircle, Loader2, Database, Clock, Settings } from 'lucide-react';
+import { Brain, Search, Trash2, AlertCircle, Loader2, Database, Clock, Settings, X } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { getAuthHeaders } from '../lib/auth';
 import { FOCUS_RING_CLASS } from '../lib/constants';
@@ -224,9 +224,29 @@ export function DreamMemoryView() {
           <input
             type="text" className="glass-input" placeholder="Search memories semantically..."
             aria-label="Search memories semantically"
-            style={{ paddingLeft: '3.25rem', width: '100%' }}
+            style={{ paddingLeft: '3.25rem', paddingRight: searchQuery ? '2.5rem' : '1rem', width: '100%' }}
             value={searchQuery} onChange={e => setSearchQuery(e.target.value)}
           />
+          {searchQuery && (
+            <button
+              type="button"
+              aria-label="Clear search"
+              onClick={() => {
+                setSearchQuery('');
+                setPage(0);
+                fetchMemories('', 0, dreamConfig);
+              }}
+              className={FOCUS_RING_CLASS}
+              style={{
+                position: 'absolute', right: '0.5rem', top: '0.85rem',
+                background: 'transparent', border: 'none', color: 'var(--text-muted)',
+                cursor: 'pointer', padding: '0.25rem', display: 'flex', alignItems: 'center', justifyContent: 'center',
+                borderRadius: '50%'
+              }}
+            >
+              <X size={16} />
+            </button>
+          )}
         </form>
 
         <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', background: 'rgba(255,255,255,0.02)', padding: '0.25rem 0.75rem', borderRadius: '14px', border: '1px solid rgba(255,255,255,0.05)' }}>

--- a/dashboard/src/components/DreamMemoryView.tsx
+++ b/dashboard/src/components/DreamMemoryView.tsx
@@ -196,6 +196,12 @@ export function DreamMemoryView() {
   const hasPrev = page > 0;
   const hasNext = memories.length >= PAGE_SIZE;
 
+  const clearSearch = () => {
+    setSearchQuery('');
+    setPage(0);
+    fetchMemories('', 0, dreamConfig);
+  };
+
   // No client-side filtering needed, as it's now handled by the API
   // const filteredMemories = memories.filter(m => selectedTypes.includes(m.memory_type));
 
@@ -231,18 +237,8 @@ export function DreamMemoryView() {
             <button
               type="button"
               aria-label="Clear search"
-              onClick={() => {
-                setSearchQuery('');
-                setPage(0);
-                fetchMemories('', 0, dreamConfig);
-              }}
-              className={FOCUS_RING_CLASS}
-              style={{
-                position: 'absolute', right: '0.5rem', top: '0.85rem',
-                background: 'transparent', border: 'none', color: 'var(--text-muted)',
-                cursor: 'pointer', padding: '0.25rem', display: 'flex', alignItems: 'center', justifyContent: 'center',
-                borderRadius: '50%'
-              }}
+              onClick={clearSearch}
+              className={`clear-search-btn ${FOCUS_RING_CLASS}`}
             >
               <X size={16} />
             </button>

--- a/dashboard/src/components/__tests__/DreamMemoryView.test.tsx
+++ b/dashboard/src/components/__tests__/DreamMemoryView.test.tsx
@@ -19,7 +19,7 @@ vi.mock('lucide-react', () => {
   const Icon = ({ size, style }: any) => <span data-testid="lucide-icon" data-size={size} style={style} />;
   return {
     Brain: Icon, Search: Icon, Trash2: Icon, AlertCircle: Icon,
-    Loader2: Icon, Database: Icon, Clock: Icon, Settings: Icon,
+    Loader2: Icon, Database: Icon, Clock: Icon, Settings: Icon, X: Icon
   };
 });
 

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -155,3 +155,19 @@ h1, h2, h3, .tech-font {
   box-shadow: 0 0 0 2px var(--primary-neon);
   border-radius: 4px;
 }
+
+/* Clear Search Button */
+.clear-search-btn {
+  position: absolute;
+  right: 0.5rem;
+  top: 0.85rem;
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+}


### PR DESCRIPTION
💡 **What:** Added a "Clear search" 'X' button inside the Dream Memory view's search input.

🎯 **Why:** To improve usability. Users typing a long search query previously had to manually backspace or select-all and delete to clear it. Now they can instantly clear the query and reset the view with a single click.

📸 **Before/After:**
Before: Just an input field.
After: The input field now displays an 'X' button on the right side when it contains text. 

♿ **Accessibility:**
- The button is an explicit `<button type="button">`.
- It includes `aria-label="Clear search"` for screen reader users.
- It utilizes the existing `FOCUS_RING_CLASS` for clear keyboard navigation visibility.

---
*PR created automatically by Jules for task [14782732948605871147](https://jules.google.com/task/14782732948605871147) started by @giauphan*