### PR TITLE
🎨 Palette: Add focus ring to KnowledgeNetwork3D button

### DIFF
--- a/dashboard/src/components/KnowledgeNetwork3D.tsx
+++ b/dashboard/src/components/KnowledgeNetwork3D.tsx
@@ -109,6 +109,8 @@ export function SphericalKnowledgeGraph({
         }}>
           <button
             className={FOCUS_RING_CLASS}
+            aria-label="Load all nodes and links into the knowledge graph"
+            title="Load all nodes and links"
             onClick={() => setShowAll(true)}
             style={{
               padding: '0.6rem 1.5rem', borderRadius: '20px', border: 'none',

--- a/dashboard/src/components/KnowledgeNetwork3D.tsx
+++ b/dashboard/src/components/KnowledgeNetwork3D.tsx
@@ -6,6 +6,7 @@
 
 import React, { useRef, useEffect, useState } from 'react';
 import ForceGraph2D from 'force-graph';
+import { FOCUS_RING_CLASS } from '../lib/constants';
 
 // ─── Types ──────────────────────────────────────────────────
 interface GraphNode {
@@ -107,6 +108,7 @@ export function SphericalKnowledgeGraph({
           zIndex: 10,
         }}>
           <button
+            className={FOCUS_RING_CLASS}
             onClick={() => setShowAll(true)}
             style={{
               padding: '0.6rem 1.5rem', borderRadius: '20px', border: 'none',

--- a/dashboard/src/components/KnowledgeNetwork3D.tsx
+++ b/dashboard/src/components/KnowledgeNetwork3D.tsx
@@ -109,7 +109,6 @@ export function SphericalKnowledgeGraph({
         }}>
           <button
             className={FOCUS_RING_CLASS}
-            aria-label="Load all nodes and links into the knowledge graph"
             title="Load all nodes and links"
             onClick={() => setShowAll(true)}
             style={{


### PR DESCRIPTION
**What:**
Added the `FOCUS_RING_CLASS` to the "Load All" button inside the `KnowledgeNetwork3D` component.

**Why:**
The "Load All" button was missing a focus indicator when navigated via keyboard. Adding the standard `FOCUS_RING_CLASS` ensures consistency with the rest of the application and improves accessibility for keyboard users.

**Before/After:**
*(Tested via Playwright locally, the component now receives a visible neon focus ring when focused via keyboard.)*

**Accessibility:**
Improved keyboard navigation visibility. Ensures the button meets WCAG requirements for focus indicators.

---
*PR created automatically by Jules for task [10354393325194714031](https://jules.google.com/task/10354393325194714031) started by @giauphan*