### PR TITLE
🎨 Palette: [a11y improvement] Add explicit focus rings to custom search inputs

### DIFF
--- a/dashboard/src/components/KnowledgeGraphView.tsx
+++ b/dashboard/src/components/KnowledgeGraphView.tsx
@@ -119,6 +119,7 @@ export const KnowledgeGraphView: React.FC<KnowledgeGraphViewProps> = ({
               onChange={e => setSearchQuery(e.target.value)}
               placeholder="Search sphere…"
               aria-label="Search knowledge graph sphere"
+              className={FOCUS_RING_CLASS}
               style={{
                 width: '100%', padding: '0.6rem 1rem 0.6rem 2.8rem', borderRadius: '12px',
                 border: '1px solid rgba(255,255,255,0.15)', background: 'rgba(0,0,0,0.7)',

--- a/dashboard/src/components/OrchestrationTasksView.tsx
+++ b/dashboard/src/components/OrchestrationTasksView.tsx
@@ -117,6 +117,7 @@ export function OrchestrationTasksView() {
             onKeyDown={e => e.key === 'Enter' && handleSearch()}
             placeholder="Search tasks by ID, description, or agent…"
             aria-label="Search orchestration tasks"
+            className={FOCUS_RING_CLASS}
             style={{
               width: '100%', padding: '0.7rem 1rem 0.7rem 2.5rem', borderRadius: '10px',
               border: '1px solid rgba(255,255,255,0.15)', background: 'rgba(0,0,0,0.3)',

--- a/dashboard/src/components/SecondBrainView.tsx
+++ b/dashboard/src/components/SecondBrainView.tsx
@@ -131,6 +131,7 @@ export function SecondBrainView() {
             onKeyDown={e => e.key === 'Enter' && handleSearch()}
             placeholder="Search concepts…"
             aria-label="Search concepts"
+            className={FOCUS_RING_CLASS}
             style={{
               width: '100%', padding: '0.7rem 1rem 0.7rem 2.5rem', borderRadius: '10px',
               border: '1px solid rgba(255,255,255,0.15)', background: 'rgba(0,0,0,0.3)',


### PR DESCRIPTION
💡 What: Added the `FOCUS_RING_CLASS` to several search input fields in the dashboard that were previously missing visible focus indicators due to inline `outline: 'none'` styling.

🎯 Why: When custom input fields are styled to hide the default browser focus ring without providing a custom alternative, keyboard-only users navigating via the Tab key cannot see which element is currently focused. This severely impacts accessibility.

📸 Before/After: Verified locally via Playwright screenshots. The search inputs in `KnowledgeGraphView`, `OrchestrationTasksView`, and `SecondBrainView` now display a clear, accessible neon focus ring when focused, matching the rest of the application's design system.

♿ Accessibility: Ensures WCAG compliance for focus visibility on interactive elements, improving the experience for keyboard-only and screen reader users.

---
*PR created automatically by Jules for task [9954373708493185406](https://jules.google.com/task/9954373708493185406) started by @giauphan*