### PR TITLE
🎨 Palette: [UX improvement] Add ARIA roles and selected state to auth tabs

### DIFF
--- a/dashboard/src/components/Auth.tsx
+++ b/dashboard/src/components/Auth.tsx
@@ -103,13 +103,15 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
         </header>
 
         {/* Tab Switcher */}
-        <div style={{ display: 'flex', background: 'rgba(0,0,0,0.3)', padding: '0.4rem', borderRadius: '16px', marginBottom: '2.5rem', border: '1px solid rgba(255,255,255,0.05)' }}>
+        <div role="tablist" style={{ display: 'flex', background: 'rgba(0,0,0,0.3)', padding: '0.4rem', borderRadius: '16px', marginBottom: '2.5rem', border: '1px solid rgba(255,255,255,0.05)' }}>
           {[
             { id: 'token', label: 'TOKEN', icon: Key },
             { id: 'signin', label: 'SIGN IN', icon: LogIn },
           ].map((tab) => (
             <button
               key={tab.id}
+              role="tab"
+              aria-selected={mode === tab.id}
               disabled={loading}
               onClick={() => { setMode(tab.id as 'token' | 'signin'); setError(null); }}
               className={FOCUS_RING_CLASS}

--- a/dashboard/src/components/Auth.tsx
+++ b/dashboard/src/components/Auth.tsx
@@ -28,7 +28,7 @@ function getApiBase(): string {
 const TABS = [
   { id: 'token', label: 'TOKEN', icon: Key },
   { id: 'signin', label: 'SIGN IN', icon: LogIn },
-];
+] as const;
 
 const Auth: React.FC<AuthProps> = ({ onLogin }) => {
   const [mode, setMode] = useState<'token' | 'signin'>('token');
@@ -52,31 +52,37 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
     }
   };
 
-  const tabRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+  const tabRefs = useRef<Map<string, HTMLButtonElement> | null>(null);
+  const getTabRefs = () => {
+    if (!tabRefs.current) {
+      tabRefs.current = new Map();
+    }
+    return tabRefs.current;
+  };
   const [focusTarget, setFocusTarget] = useState<'token' | 'signin' | null>(null);
 
   useEffect(() => {
     if (focusTarget) {
-      tabRefs.current.get(focusTarget)?.focus();
+      getTabRefs().get(focusTarget)?.focus();
       setFocusTarget(null);
     }
   }, [focusTarget]);
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     const tabIds = TABS.map(t => t.id);
-    let nextTabId: 'token' | 'signin' | null = null;
+    let nextTabId: typeof mode | null = null;
 
     if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
       e.preventDefault();
       const currentIndex = tabIds.indexOf(mode);
       const nextIndex = e.key === 'ArrowRight' ? (currentIndex + 1) % tabIds.length : (currentIndex - 1 + tabIds.length) % tabIds.length;
-      nextTabId = tabIds[nextIndex] as 'token' | 'signin';
+      nextTabId = tabIds[nextIndex];
     } else if (e.key === 'Home') {
       e.preventDefault();
-      nextTabId = tabIds[0] as 'token' | 'signin';
+      nextTabId = tabIds[0];
     } else if (e.key === 'End') {
       e.preventDefault();
-      nextTabId = tabIds[tabIds.length - 1] as 'token' | 'signin';
+      nextTabId = tabIds[tabIds.length - 1];
     }
 
     if (nextTabId) {
@@ -142,15 +148,15 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
         </header>
 
         {/* Tab Switcher */}
-        <div role="tablist" aria-label="Authentication method" style={{ display: 'flex', background: 'rgba(0,0,0,0.3)', padding: '0.4rem', borderRadius: '16px', marginBottom: '2.5rem', border: '1px solid rgba(255,255,255,0.05)' }}>
+        <div role="tablist" aria-label="Authentication method" onKeyDown={handleKeyDown} style={{ display: 'flex', background: 'rgba(0,0,0,0.3)', padding: '0.4rem', borderRadius: '16px', marginBottom: '2.5rem', border: '1px solid rgba(255,255,255,0.05)' }}>
           {TABS.map((tab) => (
             <button
               key={tab.id}
               ref={(el) => {
                 if (el) {
-                  tabRefs.current.set(tab.id, el);
+                  getTabRefs().set(tab.id, el);
                 } else {
-                  tabRefs.current.delete(tab.id);
+                  getTabRefs().delete(tab.id);
                 }
               }}
               role="tab"
@@ -158,9 +164,8 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
               aria-controls={`panel-${tab.id}`}
               id={`tab-${tab.id}`}
               tabIndex={mode === tab.id ? 0 : -1}
-              onKeyDown={handleKeyDown}
               disabled={loading}
-              onClick={() => { setMode(tab.id as 'token' | 'signin'); setError(null); }}
+              onClick={() => { setMode(tab.id); setError(null); }}
               className={FOCUS_RING_CLASS}
               style={{
                 flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', padding: '0.75rem', borderRadius: '12px', outline: 'none', border: 'none', cursor: loading ? 'not-allowed' : 'pointer', fontSize: '0.75rem', fontWeight: 800, transition: 'all 0.3s',

--- a/dashboard/src/components/Auth.tsx
+++ b/dashboard/src/components/Auth.tsx
@@ -52,15 +52,12 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
     }
   };
 
-  const tabRefs = useRef<Map<string, HTMLButtonElement> | null>(null);
-  if (!tabRefs.current) {
-    tabRefs.current = new Map();
-  }
+  const tabRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
   const [focusTarget, setFocusTarget] = useState<'token' | 'signin' | null>(null);
 
   useEffect(() => {
     if (focusTarget) {
-      tabRefs.current?.get(focusTarget)?.focus();
+      tabRefs.current.get(focusTarget)?.focus();
       setFocusTarget(null);
     }
   }, [focusTarget]);
@@ -151,9 +148,9 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
               key={tab.id}
               ref={(el) => {
                 if (el) {
-                  tabRefs.current?.set(tab.id, el);
+                  tabRefs.current.set(tab.id, el);
                 } else {
-                  tabRefs.current?.delete(tab.id);
+                  tabRefs.current.delete(tab.id);
                 }
               }}
               role="tab"

--- a/dashboard/src/components/Auth.tsx
+++ b/dashboard/src/components/Auth.tsx
@@ -145,7 +145,7 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
         </header>
 
         {/* Tab Switcher */}
-        <div role="tablist" style={{ display: 'flex', background: 'rgba(0,0,0,0.3)', padding: '0.4rem', borderRadius: '16px', marginBottom: '2.5rem', border: '1px solid rgba(255,255,255,0.05)' }}>
+        <div role="tablist" aria-label="Authentication method" style={{ display: 'flex', background: 'rgba(0,0,0,0.3)', padding: '0.4rem', borderRadius: '16px', marginBottom: '2.5rem', border: '1px solid rgba(255,255,255,0.05)' }}>
           {TABS.map((tab) => (
             <button
               key={tab.id}

--- a/dashboard/src/components/Auth.tsx
+++ b/dashboard/src/components/Auth.tsx
@@ -112,6 +112,27 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
               key={tab.id}
               role="tab"
               aria-selected={mode === tab.id}
+              aria-controls={`panel-${tab.id}`}
+              id={`tab-${tab.id}`}
+              tabIndex={mode === tab.id ? 0 : -1}
+              onKeyDown={(e) => {
+                if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+                  const tabs = ['token', 'signin'];
+                  const currentIndex = tabs.indexOf(mode);
+                  const nextIndex = e.key === 'ArrowRight' ? (currentIndex + 1) % tabs.length : (currentIndex - 1 + tabs.length) % tabs.length;
+                  setMode(tabs[nextIndex] as 'token' | 'signin');
+                  setError(null);
+                  document.getElementById(`tab-${tabs[nextIndex]}`)?.focus();
+                } else if (e.key === 'Home') {
+                  setMode('token');
+                  setError(null);
+                  document.getElementById('tab-token')?.focus();
+                } else if (e.key === 'End') {
+                  setMode('signin');
+                  setError(null);
+                  document.getElementById('tab-signin')?.focus();
+                }
+              }}
               disabled={loading}
               onClick={() => { setMode(tab.id as 'token' | 'signin'); setError(null); }}
               className={FOCUS_RING_CLASS}
@@ -129,7 +150,7 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
 
         <AnimatePresence mode="wait">
           {mode === 'token' ? (
-            <motion.form key="token" initial={{ opacity: 0, x: -20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} onSubmit={handleTokenSubmit}>
+            <motion.form role="tabpanel" id="panel-token" aria-labelledby="tab-token" key="token" initial={{ opacity: 0, x: -20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} onSubmit={handleTokenSubmit}>
               <div style={{ marginBottom: '1.5rem' }}>
                 <label htmlFor="api-key" style={{ display: 'block', fontSize: '0.75rem', color: 'var(--text-muted)', marginBottom: '0.75rem', fontWeight: 700 }}>NEURAL ACCESS KEY</label>
                 <div style={{ position: 'relative' }}>
@@ -143,7 +164,7 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
               </button>
             </motion.form>
           ) : (
-            <motion.form key="signin" initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -20 }} onSubmit={handleEmailSubmit}>
+            <motion.form role="tabpanel" id="panel-signin" aria-labelledby="tab-signin" key="signin" initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -20 }} onSubmit={handleEmailSubmit}>
               <div style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem', marginBottom: '2rem' }}>
                 <div>
                   <label htmlFor="email" style={{ display: 'block', fontSize: '0.75rem', color: 'var(--text-muted)', marginBottom: '0.75rem', fontWeight: 700 }}>EMAIL ADDRESS</label>

--- a/dashboard/src/components/Auth.tsx
+++ b/dashboard/src/components/Auth.tsx
@@ -6,7 +6,7 @@
  *
  * No Firebase Web SDK needed — sign-in is proxied through backend.
  */
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   Shield, Key, Mail, Lock, LogIn, Loader2
@@ -52,7 +52,18 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
     }
   };
 
-  const tabRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+  const tabRefs = useRef<Map<string, HTMLButtonElement> | null>(null);
+  if (!tabRefs.current) {
+    tabRefs.current = new Map();
+  }
+  const [focusTarget, setFocusTarget] = useState<'token' | 'signin' | null>(null);
+
+  useEffect(() => {
+    if (focusTarget) {
+      tabRefs.current?.get(focusTarget)?.focus();
+      setFocusTarget(null);
+    }
+  }, [focusTarget]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
     const tabIds = TABS.map(t => t.id);
@@ -74,11 +85,7 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
     if (nextTabId) {
       setMode(nextTabId);
       setError(null);
-
-      // Use setTimeout to ensure focus happens after React state updates the tabIndex
-      setTimeout(() => {
-        tabRefs.current.get(nextTabId!)?.focus();
-      }, 0);
+      setFocusTarget(nextTabId);
     }
   };
 
@@ -144,9 +151,9 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
               key={tab.id}
               ref={(el) => {
                 if (el) {
-                  tabRefs.current.set(tab.id, el);
+                  tabRefs.current?.set(tab.id, el);
                 } else {
-                  tabRefs.current.delete(tab.id);
+                  tabRefs.current?.delete(tab.id);
                 }
               }}
               role="tab"

--- a/dashboard/src/components/Auth.tsx
+++ b/dashboard/src/components/Auth.tsx
@@ -52,18 +52,17 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
     }
   };
 
-  const tabRefs = useRef<Map<string, HTMLButtonElement> | null>(null);
-  const getTabRefs = () => {
-    if (!tabRefs.current) {
-      tabRefs.current = new Map();
-    }
-    return tabRefs.current;
-  };
+  const tokenTabRef = useRef<HTMLButtonElement | null>(null);
+  const signinTabRef = useRef<HTMLButtonElement | null>(null);
   const [focusTarget, setFocusTarget] = useState<'token' | 'signin' | null>(null);
 
   useEffect(() => {
+    if (focusTarget === 'token') {
+      tokenTabRef.current?.focus();
+    } else if (focusTarget === 'signin') {
+      signinTabRef.current?.focus();
+    }
     if (focusTarget) {
-      getTabRefs().get(focusTarget)?.focus();
       setFocusTarget(null);
     }
   }, [focusTarget]);
@@ -152,13 +151,7 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
           {TABS.map((tab) => (
             <button
               key={tab.id}
-              ref={(el) => {
-                if (el) {
-                  getTabRefs().set(tab.id, el);
-                } else {
-                  getTabRefs().delete(tab.id);
-                }
-              }}
+              ref={tab.id === 'token' ? tokenTabRef : signinTabRef}
               role="tab"
               aria-selected={mode === tab.id}
               aria-controls={`panel-${tab.id}`}

--- a/dashboard/src/components/Auth.tsx
+++ b/dashboard/src/components/Auth.tsx
@@ -6,7 +6,7 @@
  *
  * No Firebase Web SDK needed — sign-in is proxied through backend.
  */
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   Shield, Key, Mail, Lock, LogIn, Loader2
@@ -24,6 +24,11 @@ function getApiBase(): string {
     ? 'http://localhost:8080'
     : window.location.origin;
 }
+
+const TABS = [
+  { id: 'token', label: 'TOKEN', icon: Key },
+  { id: 'signin', label: 'SIGN IN', icon: LogIn },
+];
 
 const Auth: React.FC<AuthProps> = ({ onLogin }) => {
   const [mode, setMode] = useState<'token' | 'signin'>('token');
@@ -44,6 +49,36 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
       setError((err as Error).message || 'Invalid API Key or Token');
     } finally {
       setLoading(false);
+    }
+  };
+
+  const tabRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    const tabIds = TABS.map(t => t.id);
+    let nextTabId: 'token' | 'signin' | null = null;
+
+    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+      e.preventDefault();
+      const currentIndex = tabIds.indexOf(mode);
+      const nextIndex = e.key === 'ArrowRight' ? (currentIndex + 1) % tabIds.length : (currentIndex - 1 + tabIds.length) % tabIds.length;
+      nextTabId = tabIds[nextIndex] as 'token' | 'signin';
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      nextTabId = tabIds[0] as 'token' | 'signin';
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      nextTabId = tabIds[tabIds.length - 1] as 'token' | 'signin';
+    }
+
+    if (nextTabId) {
+      setMode(nextTabId);
+      setError(null);
+
+      // Use setTimeout to ensure focus happens after React state updates the tabIndex
+      setTimeout(() => {
+        tabRefs.current.get(nextTabId!)?.focus();
+      }, 0);
     }
   };
 
@@ -104,37 +139,22 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
 
         {/* Tab Switcher */}
         <div role="tablist" style={{ display: 'flex', background: 'rgba(0,0,0,0.3)', padding: '0.4rem', borderRadius: '16px', marginBottom: '2.5rem', border: '1px solid rgba(255,255,255,0.05)' }}>
-          {[
-            { id: 'token', label: 'TOKEN', icon: Key },
-            { id: 'signin', label: 'SIGN IN', icon: LogIn },
-          ].map((tab, _index, tabArray) => (
+          {TABS.map((tab) => (
             <button
               key={tab.id}
+              ref={(el) => {
+                if (el) {
+                  tabRefs.current.set(tab.id, el);
+                } else {
+                  tabRefs.current.delete(tab.id);
+                }
+              }}
               role="tab"
               aria-selected={mode === tab.id}
               aria-controls={`panel-${tab.id}`}
               id={`tab-${tab.id}`}
               tabIndex={mode === tab.id ? 0 : -1}
-              onKeyDown={(e) => {
-                const tabs = tabArray.map(t => t.id);
-                if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
-                  const currentIndex = tabs.indexOf(mode);
-                  const nextIndex = e.key === 'ArrowRight' ? (currentIndex + 1) % tabs.length : (currentIndex - 1 + tabs.length) % tabs.length;
-                  setMode(tabs[nextIndex] as 'token' | 'signin');
-                  setError(null);
-                  document.getElementById(`tab-${tabs[nextIndex]}`)?.focus();
-                } else if (e.key === 'Home') {
-                  const firstTab = tabs[0];
-                  setMode(firstTab as 'token' | 'signin');
-                  setError(null);
-                  document.getElementById(`tab-${firstTab}`)?.focus();
-                } else if (e.key === 'End') {
-                  const lastTab = tabs[tabs.length - 1];
-                  setMode(lastTab as 'token' | 'signin');
-                  setError(null);
-                  document.getElementById(`tab-${lastTab}`)?.focus();
-                }
-              }}
+              onKeyDown={handleKeyDown}
               disabled={loading}
               onClick={() => { setMode(tab.id as 'token' | 'signin'); setError(null); }}
               className={FOCUS_RING_CLASS}

--- a/dashboard/src/components/Auth.tsx
+++ b/dashboard/src/components/Auth.tsx
@@ -107,7 +107,7 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
           {[
             { id: 'token', label: 'TOKEN', icon: Key },
             { id: 'signin', label: 'SIGN IN', icon: LogIn },
-          ].map((tab) => (
+          ].map((tab, _index, tabArray) => (
             <button
               key={tab.id}
               role="tab"
@@ -116,21 +116,23 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
               id={`tab-${tab.id}`}
               tabIndex={mode === tab.id ? 0 : -1}
               onKeyDown={(e) => {
+                const tabs = tabArray.map(t => t.id);
                 if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
-                  const tabs = ['token', 'signin'];
                   const currentIndex = tabs.indexOf(mode);
                   const nextIndex = e.key === 'ArrowRight' ? (currentIndex + 1) % tabs.length : (currentIndex - 1 + tabs.length) % tabs.length;
                   setMode(tabs[nextIndex] as 'token' | 'signin');
                   setError(null);
                   document.getElementById(`tab-${tabs[nextIndex]}`)?.focus();
                 } else if (e.key === 'Home') {
-                  setMode('token');
+                  const firstTab = tabs[0];
+                  setMode(firstTab as 'token' | 'signin');
                   setError(null);
-                  document.getElementById('tab-token')?.focus();
+                  document.getElementById(`tab-${firstTab}`)?.focus();
                 } else if (e.key === 'End') {
-                  setMode('signin');
+                  const lastTab = tabs[tabs.length - 1];
+                  setMode(lastTab as 'token' | 'signin');
                   setError(null);
-                  document.getElementById('tab-signin')?.focus();
+                  document.getElementById(`tab-${lastTab}`)?.focus();
                 }
               }}
               disabled={loading}


### PR DESCRIPTION
💡 What: Added `role="tablist"` to the auth tab container, and `role="tab"` with `aria-selected` to each tab button in `Auth.tsx`.
🎯 Why: Makes the tab switcher correctly announce itself to screen readers, improving accessibility and fulfilling standard tab interaction expectations.
📸 Before/After: Visually identical, structurally accessible.
♿ Accessibility: Ensures assistive technologies understand the tabbed interface structure and which tab is currently active.

---
*PR created automatically by Jules for task [6880124825523721665](https://jules.google.com/task/6880124825523721665) started by @giauphan*