### PR TITLE
⚡ Bolt: [performance improvement] Replace O(N^2) array deduplication with O(N) Set

### DIFF
--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -1000,6 +1000,13 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
       }
 
       if (seedNodes.size === 0) {
+        // Bolt Optimization: Replace O(N^2) Array.filter(indexOf) with O(N) Array.from(new Set(...))
+        const suggestions = Array.from(new Set(
+          nodes
+            .filter((n) => n.type === "function" || n.type === "class")
+            .map((n) => n.label)
+        )).slice(0, 15);
+
         return {
           content: [{
             type: "text" as const,
@@ -1007,11 +1014,7 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
               keyword,
               matchCount: 0,
               message: `No entities found matching '${keyword}'. Try a broader keyword.`,
-              suggestions: nodes
-                .filter((n) => n.type === "function" || n.type === "class")
-                .map((n) => n.label)
-                .filter((l, i, arr) => arr.indexOf(l) === i)
-                .slice(0, 15),
+              suggestions,
             }, null, 2),
           }],
         };
@@ -1250,10 +1253,12 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
         })),
         mermaidDiagram: mermaid,
         executionOrder,
-        readingOrder: executionOrder
-          .filter((e) => e.file)
-          .map((e) => e.file!)
-          .filter((f, i, arr) => arr.indexOf(f) === i),
+        // Bolt Optimization: Replace O(N^2) Array.filter(indexOf) with O(N) Array.from(new Set(...))
+        readingOrder: Array.from(new Set(
+          executionOrder
+            .filter((e) => e.file)
+            .map((e) => e.file!)
+        )),
         message: `Generated ${dType} diagram for '${keyword}': ${traceNodes.length} nodes, ${dedupLinks.length} call relationships. Entry points: ${entryPoints.map((n) => n.label).join(", ")}`,
       };
 

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -1000,7 +1000,7 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
       }
 
       if (seedNodes.size === 0) {
-        // Bolt Optimization: Replace O(N^2) Array.filter(indexOf) with O(N) Array.from(new Set(...))
+
         const suggestions = Array.from(new Set(
           nodes
             .filter((n) => n.type === "function" || n.type === "class")
@@ -1253,7 +1253,7 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
         })),
         mermaidDiagram: mermaid,
         executionOrder,
-        // Bolt Optimization: Replace O(N^2) Array.filter(indexOf) with O(N) Array.from(new Set(...))
+
         readingOrder: Array.from(new Set(
           executionOrder
             .filter((e) => e.file)


### PR DESCRIPTION
💡 What: Refactored array deduplication logic in `src/presentation/mcpTools.ts` from an $O(N^2)$ `.filter(...indexOf...)` approach to a cleaner, $O(N)$ `Array.from(new Set(...))` pattern.

🎯 Why: The previous `indexOf` nested inside `filter` forces a full iteration of the array for every single element, resulting in an $O(N^2)$ time complexity. For graph-dense structures (like parsing large module dependency nodes or execution reading orders), this causes unnecessary CPU overhead and GC pressure. 

📊 Impact: Reduces array deduplication time complexity from $O(N^2)$ to $O(N)$. Provides a slight reduction in memory allocation overhead since it prevents `filter` from processing an ever-growing index lookup during response formatting.

🔬 Measurement: Review `pnpm run build` and `pnpm test` metrics (no regressions), and inspect CPU flamegraphs on heavy `/diagram` and `/search` responses to observe eliminated `indexOf` time.

---
*PR created automatically by Jules for task [14504989867855203092](https://jules.google.com/task/14504989867855203092) started by @giauphan*