### PR TITLE
🎨 Palette: [UX improvement] Add password visibility toggles to Auth inputs

### DIFF
--- a/dashboard/src/components/Auth.tsx
+++ b/dashboard/src/components/Auth.tsx
@@ -9,7 +9,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
-  Shield, Key, Mail, Lock, LogIn, Loader2
+  Shield, Key, Mail, Lock, LogIn, Loader2, Eye, EyeOff
 } from 'lucide-react';
 import { safeSessionStorageSetItem, safeSessionStorageGetItem, safeSessionStorageRemoveItem } from '../lib/safeSessionStorage';
 import { storeAuthTokens } from '../lib/auth';
@@ -37,6 +37,8 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
   const [apiKey, setApiKey] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showToken, setShowToken] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
 
   const handleTokenSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -179,7 +181,16 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
                 <label htmlFor="api-key" style={{ display: 'block', fontSize: '0.75rem', color: 'var(--text-muted)', marginBottom: '0.75rem', fontWeight: 700 }}>NEURAL ACCESS KEY</label>
                 <div style={{ position: 'relative' }}>
                   <Key size={18} style={{ position: 'absolute', left: '1rem', top: '1rem', color: 'var(--primary-neon)' }} />
-                  <input id="api-key" type="password" style={{ paddingLeft: '3rem' }} className="glass-input" placeholder="Enter your Enterprise Key..." value={apiKey} onChange={e => setApiKey(e.target.value)} disabled={loading} required autoFocus />
+                  <input id="api-key" type={showToken ? "text" : "password"} style={{ paddingLeft: '3rem', paddingRight: '3rem' }} className="glass-input" placeholder="Enter your Enterprise Key..." value={apiKey} onChange={e => setApiKey(e.target.value)} disabled={loading} required autoFocus />
+                  <button
+                    type="button"
+                    onClick={() => setShowToken(!showToken)}
+                    className={FOCUS_RING_CLASS}
+                    aria-label={showToken ? "Hide access key" : "Show access key"}
+                    style={{ position: 'absolute', right: '0.5rem', top: '0.5rem', padding: '0.5rem', background: 'transparent', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', borderRadius: '8px' }}
+                  >
+                    {showToken ? <EyeOff size={18} /> : <Eye size={18} />}
+                  </button>
                 </div>
               </div>
               {error && <div style={{ background: 'rgba(255, 75, 75, 0.1)', border: '1px solid #ff4b4b', color: '#ff4b4b', padding: '1rem', borderRadius: '12px', fontSize: '0.8rem', marginBottom: '1.5rem', fontWeight: 600 }}>{error}</div>}
@@ -201,7 +212,16 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
                   <label htmlFor="password" style={{ display: 'block', fontSize: '0.75rem', color: 'var(--text-muted)', marginBottom: '0.75rem', fontWeight: 700 }}>PASSWORD</label>
                   <div style={{ position: 'relative' }}>
                     <Lock size={18} style={{ position: 'absolute', left: '1rem', top: '1rem', color: 'var(--primary-neon)' }} />
-                    <input id="password" type="password" autoComplete="current-password" style={{ paddingLeft: '3rem' }} className="glass-input" placeholder="••••••••" value={password} onChange={e => setPassword(e.target.value)} required />
+                    <input id="password" type={showPassword ? "text" : "password"} autoComplete="current-password" style={{ paddingLeft: '3rem', paddingRight: '3rem' }} className="glass-input" placeholder="••••••••" value={password} onChange={e => setPassword(e.target.value)} required />
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword(!showPassword)}
+                      className={FOCUS_RING_CLASS}
+                      aria-label={showPassword ? "Hide password" : "Show password"}
+                      style={{ position: 'absolute', right: '0.5rem', top: '0.5rem', padding: '0.5rem', background: 'transparent', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', borderRadius: '8px' }}
+                    >
+                      {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                    </button>
                   </div>
                 </div>
               </div>

--- a/dashboard/src/components/Auth.tsx
+++ b/dashboard/src/components/Auth.tsx
@@ -181,7 +181,7 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
                 <label htmlFor="api-key" style={{ display: 'block', fontSize: '0.75rem', color: 'var(--text-muted)', marginBottom: '0.75rem', fontWeight: 700 }}>NEURAL ACCESS KEY</label>
                 <div style={{ position: 'relative' }}>
                   <Key size={18} style={{ position: 'absolute', left: '1rem', top: '1rem', color: 'var(--primary-neon)' }} />
-                  <input id="api-key" type={showToken ? "text" : "password"} autoComplete="off" style={{ paddingLeft: '3rem', paddingRight: '3rem' }} className="glass-input" placeholder="Enter your Enterprise Key..." value={apiKey} onChange={e => setApiKey(e.target.value)} disabled={loading} required autoFocus />
+                  <input id="api-key" type={showToken ? "text" : "password"} autoComplete="off" style={{ paddingLeft: '3rem', paddingRight: '3rem' }} className="glass-input" placeholder="Enter your Enterprise Key..." value={apiKey} onChange={e => setApiKey(e.target.value)} disabled={loading} required />
                   <button
                     type="button"
                     onClick={() => setShowToken(!showToken)}

--- a/dashboard/src/components/Auth.tsx
+++ b/dashboard/src/components/Auth.tsx
@@ -181,13 +181,12 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
                 <label htmlFor="api-key" style={{ display: 'block', fontSize: '0.75rem', color: 'var(--text-muted)', marginBottom: '0.75rem', fontWeight: 700 }}>NEURAL ACCESS KEY</label>
                 <div style={{ position: 'relative' }}>
                   <Key size={18} style={{ position: 'absolute', left: '1rem', top: '1rem', color: 'var(--primary-neon)' }} />
-                  <input id="api-key" type={showToken ? "text" : "password"} style={{ paddingLeft: '3rem', paddingRight: '3rem' }} className="glass-input" placeholder="Enter your Enterprise Key..." value={apiKey} onChange={e => setApiKey(e.target.value)} disabled={loading} required autoFocus />
+                  <input id="api-key" type={showToken ? "text" : "password"} autoComplete="off" style={{ paddingLeft: '3rem', paddingRight: '3rem' }} className="glass-input" placeholder="Enter your Enterprise Key..." value={apiKey} onChange={e => setApiKey(e.target.value)} disabled={loading} required autoFocus />
                   <button
                     type="button"
                     onClick={() => setShowToken(!showToken)}
-                    className={FOCUS_RING_CLASS}
+                    className={`password-toggle-btn ${FOCUS_RING_CLASS}`}
                     aria-label={showToken ? "Hide access key" : "Show access key"}
-                    style={{ position: 'absolute', right: '0.5rem', top: '0.5rem', padding: '0.5rem', background: 'transparent', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', borderRadius: '8px' }}
                   >
                     {showToken ? <EyeOff size={18} /> : <Eye size={18} />}
                   </button>
@@ -216,9 +215,8 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
                     <button
                       type="button"
                       onClick={() => setShowPassword(!showPassword)}
-                      className={FOCUS_RING_CLASS}
+                      className={`password-toggle-btn ${FOCUS_RING_CLASS}`}
                       aria-label={showPassword ? "Hide password" : "Show password"}
-                      style={{ position: 'absolute', right: '0.5rem', top: '0.5rem', padding: '0.5rem', background: 'transparent', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', borderRadius: '8px' }}
                     >
                       {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
                     </button>
@@ -235,6 +233,7 @@ const Auth: React.FC<AuthProps> = ({ onLogin }) => {
       </div>
 
       <style>{`
+        .password-toggle-btn { position: absolute; right: 0.5rem; top: 0.5rem; padding: 0.5rem; background: transparent; border: none; color: var(--text-muted); cursor: pointer; border-radius: 8px; }
         .glass-panel { background: rgba(13, 17, 23, 0.8); backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px); }
         .glass-input { background: rgba(0,0,0,0.4); border: 1px solid rgba(255,255,255,0.1); color: #fff; padding: 0.875rem 1rem; border-radius: 14px; width: 100%; transition: all 0.3s; font-size: 0.95rem; }
         .glass-input:focus { outline: none; border-color: var(--primary-neon); box-shadow: 0 0 20px rgba(0, 240, 255, 0.15); }

--- a/dashboard/src/components/__tests__/Dashboard.test.tsx
+++ b/dashboard/src/components/__tests__/Dashboard.test.tsx
@@ -63,6 +63,8 @@ vi.mock('lucide-react', () => {
     RefreshCw: MockIcon,
     Clock: MockIcon,
     Save: MockIcon,
+    Eye: MockIcon,
+    EyeOff: MockIcon,
   };
 });
 

--- a/dashboard/src/components/__tests__/DreamMemoryView.test.tsx
+++ b/dashboard/src/components/__tests__/DreamMemoryView.test.tsx
@@ -19,7 +19,8 @@ vi.mock('lucide-react', () => {
   const Icon = ({ size, style }: any) => <span data-testid="lucide-icon" data-size={size} style={style} />;
   return {
     Brain: Icon, Search: Icon, Trash2: Icon, AlertCircle: Icon,
-    Loader2: Icon, Database: Icon, Clock: Icon, Settings: Icon, X: Icon
+    Loader2: Icon, Database: Icon, Clock: Icon, Settings: Icon, X: Icon,
+    Eye: Icon, EyeOff: Icon
   };
 });
 

--- a/dashboard/src/components/__tests__/MemoryTreeView.test.tsx
+++ b/dashboard/src/components/__tests__/MemoryTreeView.test.tsx
@@ -13,6 +13,8 @@ vi.mock('lucide-react', () => {
     GitBranch: Icon,
     Loader2: Icon,
     RefreshCw: Icon,
+    Eye: Icon,
+    EyeOff: Icon,
   };
 });
 


### PR DESCRIPTION
💡 What: Added password visibility toggles (Eye/EyeOff) to the Neural Access Key and Password input fields on the Auth screen.
🎯 Why: Allowing users to easily show/hide their credentials is a crucial UX improvement, especially when pasting complex API keys or long passwords where mistakes are common.
📸 Before/After: Visual change in the input fields where an eye icon allows toggling visibility.
♿ Accessibility: The buttons are fully keyboard navigable (`FOCUS_RING_CLASS`), use `type="button"` to avoid accidental form submissions, and include dynamic `aria-label` tags (e.g., "Show password" / "Hide password") for screen readers.

---
*PR created automatically by Jules for task [2891596205406985685](https://jules.google.com/task/2891596205406985685) started by @giauphan*