### PR TITLE
⚡ Bolt: [performance improvement] Replace O(N^2) array deduplication with O(N) Set-based approach

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,7 @@
 ## 2024-05-18 - Batch Database Updates
 **Learning:** Database updates performed inside an iteration loop (e.g. `await db.execute(...)` for each concept scoring) result in severe N+1 latency issues on scale.
 **Action:** Always refactor iterative database operations to accumulate bind parameters in an array and dispatch a single grouped query with `await db.executeMany(...)`. Remember to adapt unit test assertions as well (`mockDbAdapter.executeMany.mock.calls`).
+
+## 2026-09-05 - Array deduplication
+**Learning:** `Array.from(new Set(arr))` is significantly faster than `arr.filter((v, i, arr) => arr.indexOf(v) === i)` because `indexOf` results in an $O(N^2)$ time complexity for large arrays.
+**Action:** When deduplicating arrays, avoid $O(N^2)$ time complexity bottlenecks by using an $O(N)$ Set-based approach.

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -1007,10 +1007,10 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
               keyword,
               matchCount: 0,
               message: `No entities found matching '${keyword}'. Try a broader keyword.`,
-              suggestions: nodes
+              // Using Set for O(n) deduplication
+              suggestions: Array.from(new Set(nodes
                 .filter((n) => n.type === "function" || n.type === "class")
-                .map((n) => n.label)
-                .filter((l, i, arr) => arr.indexOf(l) === i)
+                .map((n) => n.label)))
                 .slice(0, 15),
             }, null, 2),
           }],
@@ -1250,10 +1250,10 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
         })),
         mermaidDiagram: mermaid,
         executionOrder,
-        readingOrder: executionOrder
+        // Using Set for O(n) deduplication
+        readingOrder: Array.from(new Set(executionOrder
           .filter((e) => e.file)
-          .map((e) => e.file!)
-          .filter((f, i, arr) => arr.indexOf(f) === i),
+          .map((e) => e.file!))),
         message: `Generated ${dType} diagram for '${keyword}': ${traceNodes.length} nodes, ${dedupLinks.length} call relationships. Entry points: ${entryPoints.map((n) => n.label).join(", ")}`,
       };
 

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -1007,7 +1007,6 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
               keyword,
               matchCount: 0,
               message: `No entities found matching '${keyword}'. Try a broader keyword.`,
-              // Using Set for O(n) deduplication
               suggestions: Array.from(new Set(nodes
                 .filter((node) => node.type === "function" || node.type === "class")
                 .map((node) => node.label)))
@@ -1250,7 +1249,6 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
         })),
         mermaidDiagram: mermaid,
         executionOrder,
-        // Using Set for O(n) deduplication
         readingOrder: Array.from(new Set(executionOrder
           .filter((event) => event.file)
           .map((event) => event.file!))),

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -1009,8 +1009,8 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
               message: `No entities found matching '${keyword}'. Try a broader keyword.`,
               // Using Set for O(n) deduplication
               suggestions: Array.from(new Set(nodes
-                .filter((n) => n.type === "function" || n.type === "class")
-                .map((n) => n.label)))
+                .filter((node) => node.type === "function" || node.type === "class")
+                .map((node) => node.label)))
                 .slice(0, 15),
             }, null, 2),
           }],
@@ -1252,8 +1252,8 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
         executionOrder,
         // Using Set for O(n) deduplication
         readingOrder: Array.from(new Set(executionOrder
-          .filter((e) => e.file)
-          .map((e) => e.file!))),
+          .filter((event) => event.file)
+          .map((event) => event.file!))),
         message: `Generated ${dType} diagram for '${keyword}': ${traceNodes.length} nodes, ${dedupLinks.length} call relationships. Entry points: ${entryPoints.map((n) => n.label).join(", ")}`,
       };
 


### PR DESCRIPTION
💡 What: Replaced `arr.filter((v, i, arr) => arr.indexOf(v) === i)` with `Array.from(new Set(arr))` in two places in `src/presentation/mcpTools.ts`.
🎯 Why: The original approach uses `indexOf` within `filter`, leading to an O(N^2) time complexity, which could be slow for large arrays. The `Set` approach provides an optimal O(N) time complexity.
📊 Impact: Expected to reduce processing time and latency when generating diagrams and suggestions that require array deduplication for large node lists.
🔬 Measurement: Verify there are no functional regressions in diagram generations and suggestions, and observe a reduction in time taken for those operations.

---
*PR created automatically by Jules for task [4878240763936269736](https://jules.google.com/task/4878240763936269736) started by @giauphan*