### PR TITLE
⚡ Bolt: [performance improvement] Replace O(N^2) indexOf deduplication with O(N) Sets

### DIFF
--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -1007,10 +1007,9 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
               keyword,
               matchCount: 0,
               message: `No entities found matching '${keyword}'. Try a broader keyword.`,
-              suggestions: nodes
+              suggestions: Array.from(new Set(nodes
                 .filter((n) => n.type === "function" || n.type === "class")
-                .map((n) => n.label)
-                .filter((l, i, arr) => arr.indexOf(l) === i)
+                .map((n) => n.label)))
                 .slice(0, 15),
             }, null, 2),
           }],
@@ -1250,10 +1249,9 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
         })),
         mermaidDiagram: mermaid,
         executionOrder,
-        readingOrder: executionOrder
+        readingOrder: Array.from(new Set(executionOrder
           .filter((e) => e.file)
-          .map((e) => e.file!)
-          .filter((f, i, arr) => arr.indexOf(f) === i),
+          .map((e) => e.file!))),
         message: `Generated ${dType} diagram for '${keyword}': ${traceNodes.length} nodes, ${dedupLinks.length} call relationships. Entry points: ${entryPoints.map((n) => n.label).join(", ")}`,
       };
 


### PR DESCRIPTION
💡 **What:** Replaced the classic $O(N^2)$ `indexOf`-based array deduplication pattern with an $O(N)$ `Set`-based approach in `src/presentation/mcpTools.ts`.
🎯 **Why:** To improve execution speed when generating reading orders and suggestions from larger arrays in the MCP tool execution path. 
📊 **Impact:** Reduces time complexity of array deduplication operations from $O(N^2)$ to $O(N)$.
🔬 **Measurement:** Verify with large project diagrams/entity suggestions where deduplication execution time will be noticeably decreased. All unit tests successfully pass, confirming functionality is fully preserved.

---
*PR created automatically by Jules for task [969875123559871679](https://jules.google.com/task/969875123559871679) started by @giauphan*