### PR TITLE
⚡ Bolt: [performance improvement] optimize array deduplication in mcpTools.ts

### DIFF
--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -1007,11 +1007,11 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
               keyword,
               matchCount: 0,
               message: `No entities found matching '${keyword}'. Try a broader keyword.`,
-              suggestions: nodes
-                .filter((n) => n.type === "function" || n.type === "class")
-                .map((n) => n.label)
-                .filter((l, i, arr) => arr.indexOf(l) === i)
-                .slice(0, 15),
+              suggestions: Array.from(new Set(
+                nodes
+                  .filter((n) => n.type === "function" || n.type === "class")
+                  .map((n) => n.label)
+              )).slice(0, 15),
             }, null, 2),
           }],
         };
@@ -1250,10 +1250,11 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
         })),
         mermaidDiagram: mermaid,
         executionOrder,
-        readingOrder: executionOrder
-          .filter((e) => e.file)
-          .map((e) => e.file!)
-          .filter((f, i, arr) => arr.indexOf(f) === i),
+        readingOrder: Array.from(new Set(
+          executionOrder
+            .filter((e) => e.file)
+            .map((e) => e.file!)
+        )),
         message: `Generated ${dType} diagram for '${keyword}': ${traceNodes.length} nodes, ${dedupLinks.length} call relationships. Entry points: ${entryPoints.map((n) => n.label).join(", ")}`,
       };
 


### PR DESCRIPTION
💡 What: Replaced $O(N^2)$ array deduplication logic (`array.filter((v, i, arr) => arr.indexOf(v) === i)`) with $O(N)$ Set deduplication (`Array.from(new Set(array))`) in `src/presentation/mcpTools.ts`.
🎯 Why: The original approach using `.filter()` and `indexOf()` has a quadratic time complexity, leading to severe performance degradation when processing large lists of nodes or files during MCP tool execution (e.g., trace mapping and reading orders).
📊 Impact: Changes the deduplication complexity from $O(N^2)$ to $O(N)$, significantly reducing CPU time and garbage collection pressure on large payloads.
🔬 Measurement: Verify by executing large diagrams or trace summaries and noting the reduced synchronous blocking time compared to before.

---
*PR created automatically by Jules for task [3638436562525373897](https://jules.google.com/task/3638436562525373897) started by @giauphan*