### PR TITLE
🎨 Palette: Add loading state to Memory Tree refresh button

### DIFF
--- a/dashboard/src/components/MemoryTreeView.tsx
+++ b/dashboard/src/components/MemoryTreeView.tsx
@@ -227,8 +227,9 @@ export function MemoryTreeView() {
             <option value="">All projects</option>
             {projects.map(project => <option key={project} value={project}>{project}</option>)}
           </select>
-          <button type="button" onClick={fetchMemories} className={FOCUS_RING_CLASS} disabled={loading} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', padding: '0.6rem 0.9rem', borderRadius: 8, border: '1px solid rgba(0,240,255,0.3)', background: 'rgba(0,240,255,0.08)', color: 'var(--primary-neon)', cursor: 'pointer' }}>
-            <RefreshCw size={16} /> Refresh
+          <button type="button" onClick={fetchMemories} className={FOCUS_RING_CLASS} disabled={loading} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', padding: '0.6rem 0.9rem', borderRadius: 8, border: '1px solid rgba(0,240,255,0.3)', background: 'rgba(0,240,255,0.08)', color: 'var(--primary-neon)', cursor: 'pointer', opacity: loading ? 0.7 : 1 }}>
+            {loading ? <Loader2 className="animate-spin" size={16} /> : <RefreshCw size={16} />}
+            {loading ? 'Refreshing...' : 'Refresh'}
           </button>
         </div>
       </header>


### PR DESCRIPTION
💡 What: Replaced the static refresh icon on the Memory Tree view's 'Refresh' button with a spinning loader and updated the text to 'Refreshing...' while a fetch is in progress.
🎯 Why: To provide clear, immediate visual feedback to the user during an asynchronous operation (fetching memories).
📸 Before/After: Verified locally with playwright screenshots (memory-tree-loading.png shows "Refreshing..." and the Loader2 spinner).
♿ Accessibility: Preserved the button text while loading (appending text next to the spinner) to ensure screen readers announce the state and to prevent layout jank.

---
*PR created automatically by Jules for task [12598575768285107168](https://jules.google.com/task/12598575768285107168) started by @giauphan*