### PR TITLE
🎨 Palette: Enable clear button on task search

### DIFF
--- a/dashboard/src/components/OrchestrationTasksView.tsx
+++ b/dashboard/src/components/OrchestrationTasksView.tsx
@@ -117,7 +117,8 @@ export function OrchestrationTasksView() {
             onSearch={handleSearch}
             placeholder="Search tasks by ID, description, or agent…"
             ariaLabel="Search orchestration tasks"
-            hasClearButton={false}
+            hasClearButton={true}
+            onClear={() => setSearchQuery('')}
           />
         </div>
         <div role="group" aria-label="Filter tasks by state" style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>


### PR DESCRIPTION
💡 **What:** Enabled the `hasClearButton={true}` prop and provided an `onClear` handler to the `SearchInputWithHint` component in the `OrchestrationTasksView` page.
🎯 **Why:** To prevent users from having to manually backspace to delete their search queries, providing a faster and more intuitive one-click reset experience. This matches the established pattern already found in other views like `DreamMemoryView`.
📸 **Before/After:** (Visual change - added an 'X' clear button inside the search input when text is entered, which smoothly shifts the "Enter" hint to make room).
♿ **Accessibility:** The clear button receives the standard focus ring and aria-label "Clear search" built into the `SearchInputWithHint` component, keeping it fully accessible.

---
*PR created automatically by Jules for task [11686518447116801378](https://jules.google.com/task/11686518447116801378) started by @giauphan*