### PR TITLE
⚡ Bolt: Replace O(N) array indexOf with O(1) Map lookup in sort

### DIFF
--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -453,7 +453,7 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
 
       // Truncate if too many nodes
       if (nodes.length > max) {
-        // ⚡ Bolt Optimization: Replace O(N) array indexOf with O(1) Map lookup in sort
+        // Use Map for O(1) priority lookup
         nodes.sort((a, b) => {
           const ia = NODE_PRIORITY_ORDER.get(a.type) ?? 99;
           const ib = NODE_PRIORITY_ORDER.get(b.type) ?? 99;

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -79,6 +79,8 @@ function a2aReal(name: string, description: string, params: string[], handler: (
 
 import { injectAuthContext } from '../utils/authContext.js';
 
+const NODE_PRIORITY_ORDER = new Map([["module", 0], ["class", 1], ["function", 2], ["variable", 3]]);
+
 export function registerTools(server: McpServer, sessionAuth?: { tier: string; uid: string; keyId: string }) {
   injectAuthContext(server, sessionAuth);
 
@@ -451,11 +453,11 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
 
       // Truncate if too many nodes
       if (nodes.length > max) {
-        const priorityOrder = ["module", "class", "function", "variable"];
+        // ⚡ Bolt Optimization: Replace O(N) array indexOf with O(1) Map lookup in sort
         nodes.sort((a, b) => {
-          const ia = priorityOrder.indexOf(a.type);
-          const ib = priorityOrder.indexOf(b.type);
-          return (ia === -1 ? 99 : ia) - (ib === -1 ? 99 : ib);
+          const ia = NODE_PRIORITY_ORDER.get(a.type) ?? 99;
+          const ib = NODE_PRIORITY_ORDER.get(b.type) ?? 99;
+          return ia - ib;
         });
         nodes = nodes.slice(0, max);
       }


### PR DESCRIPTION
💡 What: Replaced an $O(N)$ `indexOf` lookup inside an array sort comparator in `mcpTools.ts` with a hoisted, $O(1)$ constant `Map` lookup.
🎯 Why: Array `indexOf` operations within a sort comparator result in $O(N \log N \cdot K)$ performance (where $K$ is the length of the priority array), introducing unnecessary overhead.
📊 Impact: Eliminates redundant array traversals and garbage collection in hot path sorting logic.
🔬 Measurement: Verify changes by checking that all tests pass (`pnpm test`), ensuring the sort order output remains consistent.

---
*PR created automatically by Jules for task [6022414751536011626](https://jules.google.com/task/6022414751536011626) started by @giauphan*