### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix HTTP Parameter Pollution (HPP) vulnerability by blocking array query parameters

### DIFF
--- a/src/middleware/validation.ts
+++ b/src/middleware/validation.ts
@@ -1,5 +1,4 @@
 import express from "express";
-import { logger } from "../utils/logger.js";
 
 /**
  * Middleware to reject array query parameters to prevent HTTP Parameter Pollution (HPP).
@@ -7,15 +6,13 @@ import { logger } from "../utils/logger.js";
  */
 export function rejectArrayParams(...paramNames: string[]) {
   if (paramNames.length === 0) {
-    logger.warn("[rejectArrayParams] Middleware created with empty paramNames array.");
+    throw new Error("[rejectArrayParams] Middleware must be initialized with at least one parameter name.");
   }
 
   return (req: express.Request, res: express.Response, next: express.NextFunction): void => {
-    if (paramNames.length === 0) return next();
-
-    const offending = paramNames.filter(p => typeof req.query[p] !== 'undefined' && typeof req.query[p] !== 'string');
+    const offending = paramNames.filter(p => Array.isArray(req.query[p]));
     if (offending.length > 0) {
-      res.status(400).json({ error: `Bad Request: invalid parameter type for [${offending.join(', ')}], string expected` });
+      res.status(400).json({ error: `Bad Request: array parameters not supported for [${offending.join(', ')}]` });
       return;
     }
     next();

--- a/src/middleware/validation.ts
+++ b/src/middleware/validation.ts
@@ -1,0 +1,15 @@
+import express from "express";
+
+/**
+ * Middleware to reject array query parameters to prevent HTTP Parameter Pollution (HPP).
+ * @param paramNames - List of query parameter keys to validate.
+ */
+export function rejectArrayParams(...paramNames: string[]) {
+  return (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (paramNames.some(p => Array.isArray(req.query[p]))) {
+      res.status(400).json({ error: "Bad Request: array parameters not supported" });
+      return;
+    }
+    next();
+  };
+}

--- a/src/middleware/validation.ts
+++ b/src/middleware/validation.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import { logger } from "../utils/logger.js";
 
 /**
  * Middleware to reject array query parameters to prevent HTTP Parameter Pollution (HPP).
@@ -6,6 +7,11 @@ import express from "express";
  */
 export function rejectArrayParams(...paramNames: string[]) {
   return (req: express.Request, res: express.Response, next: express.NextFunction): void => {
+    if (paramNames.length === 0) {
+      logger.warn("[rejectArrayParams] Middleware applied with empty paramNames array. Skipping.");
+      return next();
+    }
+
     if (paramNames.some(p => typeof req.query[p] !== 'undefined' && typeof req.query[p] !== 'string')) {
       res.status(400).json({ error: "Bad Request: invalid parameter type, string expected" });
       return;

--- a/src/middleware/validation.ts
+++ b/src/middleware/validation.ts
@@ -5,9 +5,9 @@ import express from "express";
  * @param paramNames - List of query parameter keys to validate.
  */
 export function rejectArrayParams(...paramNames: string[]) {
-  return (req: express.Request, res: express.Response, next: express.NextFunction) => {
-    if (paramNames.some(p => Array.isArray(req.query[p]))) {
-      res.status(400).json({ error: "Bad Request: array parameters not supported" });
+  return (req: express.Request, res: express.Response, next: express.NextFunction): void => {
+    if (paramNames.some(p => typeof req.query[p] !== 'undefined' && typeof req.query[p] !== 'string')) {
+      res.status(400).json({ error: "Bad Request: invalid parameter type, string expected" });
       return;
     }
     next();

--- a/src/middleware/validation.ts
+++ b/src/middleware/validation.ts
@@ -1,7 +1,8 @@
 import express from "express";
 
 /**
- * Middleware to reject array query parameters to prevent HTTP Parameter Pollution (HPP).
+ * Middleware to reject non-string query parameters (arrays, objects) to prevent HTTP Parameter Pollution (HPP).
+ * Note: Only validates parameters that are present in the request. `undefined` parameters pass through untouched.
  * @param paramNames - List of query parameter keys to validate.
  */
 export function rejectArrayParams(...paramNames: string[]) {
@@ -15,7 +16,7 @@ export function rejectArrayParams(...paramNames: string[]) {
       return val !== undefined && typeof val !== 'string';
     });
     if (offending.length > 0) {
-      res.status(400).json({ error: "Bad Request: malformed query parameters" });
+      res.status(400).json({ error: `Bad Request: malformed query parameters: ${offending.join(", ")}` });
       return;
     }
     next();

--- a/src/middleware/validation.ts
+++ b/src/middleware/validation.ts
@@ -10,9 +10,12 @@ export function rejectArrayParams(...paramNames: string[]) {
   }
 
   return (req: express.Request, res: express.Response, next: express.NextFunction): void => {
-    const offending = paramNames.filter(p => Array.isArray(req.query[p]));
+    const offending = paramNames.filter(p => {
+      const val = req.query[p];
+      return val !== undefined && typeof val !== 'string';
+    });
     if (offending.length > 0) {
-      res.status(400).json({ error: `Bad Request: array parameters not supported for [${offending.join(', ')}]` });
+      res.status(400).json({ error: "Bad Request: malformed query parameters" });
       return;
     }
     next();

--- a/src/middleware/validation.ts
+++ b/src/middleware/validation.ts
@@ -6,14 +6,16 @@ import { logger } from "../utils/logger.js";
  * @param paramNames - List of query parameter keys to validate.
  */
 export function rejectArrayParams(...paramNames: string[]) {
-  return (req: express.Request, res: express.Response, next: express.NextFunction): void => {
-    if (paramNames.length === 0) {
-      logger.warn("[rejectArrayParams] Middleware applied with empty paramNames array. Skipping.");
-      return next();
-    }
+  if (paramNames.length === 0) {
+    logger.warn("[rejectArrayParams] Middleware created with empty paramNames array.");
+  }
 
-    if (paramNames.some(p => typeof req.query[p] !== 'undefined' && typeof req.query[p] !== 'string')) {
-      res.status(400).json({ error: "Bad Request: invalid parameter type, string expected" });
+  return (req: express.Request, res: express.Response, next: express.NextFunction): void => {
+    if (paramNames.length === 0) return next();
+
+    const offending = paramNames.filter(p => typeof req.query[p] !== 'undefined' && typeof req.query[p] !== 'string');
+    if (offending.length > 0) {
+      res.status(400).json({ error: `Bad Request: invalid parameter type for [${offending.join(', ')}], string expected` });
       return;
     }
     next();

--- a/src/presentation/a2a/heartbeatRoutes.ts
+++ b/src/presentation/a2a/heartbeatRoutes.ts
@@ -18,6 +18,11 @@ export function mountHeartbeatRoutes(app: express.Express): void {
 
   // Register an agent
   app.get("/a2a/register", a2aRateLimiter, authMiddleware, (req, res) => {
+    if (Array.isArray(req.query.agent_url) || Array.isArray(req.query.agent_name) || Array.isArray(req.query.capabilities)) {
+      res.status(400).json({ error: "Bad Request: array parameters not supported" });
+      return;
+    }
+
     const agentUrl = req.query.agent_url as string;
     const agentName = req.query.agent_name as string || "Unknown Agent";
     const capabilities = (req.query.capabilities as string || "").split(",").filter(Boolean);

--- a/src/presentation/a2a/heartbeatRoutes.ts
+++ b/src/presentation/a2a/heartbeatRoutes.ts
@@ -11,18 +11,14 @@ import express from "express";
 import { a2aRegistry } from "../../services/a2aRegistry.js";
 import { logger } from "../../utils/logger.js";
 import { authMiddleware } from "../../middleware/auth.js";
+import { rejectArrayParams } from "../../middleware/validation.js";
 import { countMatching } from "../../utils/array.js";
 import { a2aRateLimiter } from "./a2aRoutes.js";
 
 export function mountHeartbeatRoutes(app: express.Express): void {
 
   // Register an agent
-  app.get("/a2a/register", a2aRateLimiter, authMiddleware, (req, res) => {
-    if (Array.isArray(req.query.agent_url) || Array.isArray(req.query.agent_name) || Array.isArray(req.query.capabilities)) {
-      res.status(400).json({ error: "Bad Request: array parameters not supported" });
-      return;
-    }
-
+  app.get("/a2a/register", a2aRateLimiter, authMiddleware, rejectArrayParams("agent_url", "agent_name", "capabilities"), (req, res) => {
     const agentUrl = req.query.agent_url as string;
     const agentName = req.query.agent_name as string || "Unknown Agent";
     const capabilities = (req.query.capabilities as string || "").split(",").filter(Boolean);

--- a/src/presentation/consolidationRoutes.ts
+++ b/src/presentation/consolidationRoutes.ts
@@ -4,6 +4,7 @@
 import express from "express";
 import { consolidationEngine, type ConsolidationJob } from "../services/consolidationEngine.js";
 import { authMiddleware } from "../services/authService.js";
+import { rejectArrayParams } from "../middleware/validation.js";
 import { logger } from "../utils/logger.js";
 import rateLimit from "express-rate-limit";
 
@@ -32,13 +33,8 @@ export function mountConsolidationRoutes(app: express.Application): void {
   });
 
   // GET /api/concepts/search — Search concepts by text
-  app.get("/api/concepts/search", consolidationRateLimiter, authMiddleware, async (req: express.Request, res: express.Response) => {
+  app.get("/api/concepts/search", consolidationRateLimiter, authMiddleware, rejectArrayParams("query", "project", "limit"), async (req: express.Request, res: express.Response) => {
     try {
-      if (Array.isArray(req.query.query) || Array.isArray(req.query.project) || Array.isArray(req.query.limit)) {
-        res.status(400).json({ error: "Bad Request: array parameters not supported" });
-        return;
-      }
-
       const query = String(req.query.query || "");
       const project = req.query.project as string | undefined;
       const limit = Math.min(Number(req.query.limit) || 10, 50);

--- a/src/presentation/consolidationRoutes.ts
+++ b/src/presentation/consolidationRoutes.ts
@@ -34,6 +34,11 @@ export function mountConsolidationRoutes(app: express.Application): void {
   // GET /api/concepts/search — Search concepts by text
   app.get("/api/concepts/search", consolidationRateLimiter, authMiddleware, async (req: express.Request, res: express.Response) => {
     try {
+      if (Array.isArray(req.query.query) || Array.isArray(req.query.project) || Array.isArray(req.query.limit)) {
+        res.status(400).json({ error: "Bad Request: array parameters not supported" });
+        return;
+      }
+
       const query = String(req.query.query || "");
       const project = req.query.project as string | undefined;
       const limit = Math.min(Number(req.query.limit) || 10, 50);

--- a/src/presentation/dreamingRoutes.ts
+++ b/src/presentation/dreamingRoutes.ts
@@ -48,7 +48,8 @@ export function registerDreamingRoutes(app: express.Application): void {
       const auth = await checkAuth(apiKey, bearerToken);
 
       if (Array.isArray(req.query.id)) {
-        return res.status(400).json({ error: "Bad Request: array parameters not supported for id" });
+        res.status(400).json({ error: "Bad Request: array parameters not supported for id" });
+        return;
       }
 
       const id = req.query.id as string | undefined;
@@ -121,8 +122,9 @@ export function registerDreamingRoutes(app: express.Application): void {
     try {
       const auth = authStorage.getStore()!;
 
-      if (Array.isArray(req.query.query) || Array.isArray(req.query.project)) {
-        return res.status(400).json({ error: "Bad Request: array parameters not supported" });
+      if (Array.isArray(req.query.query) || Array.isArray(req.query.project) || Array.isArray(req.query.limit)) {
+        res.status(400).json({ error: "Bad Request: array parameters not supported" });
+        return;
       }
 
       const queryText = (req.query.query as string)?.trim() || "";

--- a/src/presentation/dreamingRoutes.ts
+++ b/src/presentation/dreamingRoutes.ts
@@ -47,7 +47,6 @@ export function registerDreamingRoutes(app: express.Application): void {
     try {
       const { apiKey, bearerToken } = extractAuth(req);
       const auth = await checkAuth(apiKey, bearerToken);
-
       const id = req.query.id as string | undefined;
       if (!id?.trim()) return res.status(400).json({ error: "Missing or invalid id parameter" });
 
@@ -117,7 +116,6 @@ export function registerDreamingRoutes(app: express.Application): void {
   app.get("/api/dreams/query", authMiddleware, rejectArrayParams("query", "project", "limit"), async (req, res) => {
     try {
       const auth = authStorage.getStore()!;
-
       const queryText = (req.query.query as string)?.trim() || "";
       const project = req.query.project as string | undefined;
       const limitRaw = req.query.limit as string | undefined;

--- a/src/presentation/dreamingRoutes.ts
+++ b/src/presentation/dreamingRoutes.ts
@@ -46,6 +46,11 @@ export function registerDreamingRoutes(app: express.Application): void {
     try {
       const { apiKey, bearerToken } = extractAuth(req);
       const auth = await checkAuth(apiKey, bearerToken);
+
+      if (Array.isArray(req.query.id)) {
+        return res.status(400).json({ error: "Bad Request: array parameters not supported for id" });
+      }
+
       const id = req.query.id as string | undefined;
       if (!id?.trim()) return res.status(400).json({ error: "Missing or invalid id parameter" });
 
@@ -115,6 +120,11 @@ export function registerDreamingRoutes(app: express.Application): void {
   app.get("/api/dreams/query", authMiddleware, async (req, res) => {
     try {
       const auth = authStorage.getStore()!;
+
+      if (Array.isArray(req.query.query) || Array.isArray(req.query.project)) {
+        return res.status(400).json({ error: "Bad Request: array parameters not supported" });
+      }
+
       const queryText = (req.query.query as string)?.trim() || "";
       const project = req.query.project as string | undefined;
       const limitRaw = req.query.limit as string | undefined;

--- a/src/presentation/dreamingRoutes.ts
+++ b/src/presentation/dreamingRoutes.ts
@@ -5,6 +5,7 @@ import { loadAnalysisAsync } from "../services/projectService.js";
 import { authStorage } from "../utils/context.js";
 import { logger } from "../utils/logger.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { rejectArrayParams } from "../middleware/validation.js";
 import { DreamPipelineService } from "../services/dreamPipelineService.js";
 
 const VALID_MEMORY_TYPES = ["MISTAKE", "PREFERENCE", "KNOWLEDGE", "PATTERN", "SESSION_SUMMARY"] as const;
@@ -42,15 +43,10 @@ function handleError(res: express.Response, err: unknown, context: string) {
 
 export function registerDreamingRoutes(app: express.Application): void {
 
-  app.delete("/api/dreams/delete", async (req, res) => {
+  app.delete("/api/dreams/delete", rejectArrayParams("id"), async (req, res) => {
     try {
       const { apiKey, bearerToken } = extractAuth(req);
       const auth = await checkAuth(apiKey, bearerToken);
-
-      if (Array.isArray(req.query.id)) {
-        res.status(400).json({ error: "Bad Request: array parameters not supported for id" });
-        return;
-      }
 
       const id = req.query.id as string | undefined;
       if (!id?.trim()) return res.status(400).json({ error: "Missing or invalid id parameter" });
@@ -118,14 +114,9 @@ export function registerDreamingRoutes(app: express.Application): void {
   });
 
   // GET /api/dreams/query — authenticated, tenant-isolated
-  app.get("/api/dreams/query", authMiddleware, async (req, res) => {
+  app.get("/api/dreams/query", authMiddleware, rejectArrayParams("query", "project", "limit"), async (req, res) => {
     try {
       const auth = authStorage.getStore()!;
-
-      if (Array.isArray(req.query.query) || Array.isArray(req.query.project) || Array.isArray(req.query.limit)) {
-        res.status(400).json({ error: "Bad Request: array parameters not supported" });
-        return;
-      }
 
       const queryText = (req.query.query as string)?.trim() || "";
       const project = req.query.project as string | undefined;

--- a/src/presentation/genomeRoutes.ts
+++ b/src/presentation/genomeRoutes.ts
@@ -4,6 +4,7 @@
 import express from "express";
 import { GenomeService } from "../services/genomeService.js";
 import { authMiddleware } from "../services/authService.js";
+import { rejectArrayParams } from "../middleware/validation.js";
 import { logger } from "../utils/logger.js";
 import rateLimit from "express-rate-limit";
 
@@ -47,14 +48,8 @@ export function mountGenomeRoutes(app: express.Application): void {
   });
 
   // GET /api/genome/search — Semantic search genes
-  app.get("/api/genome/search", genomeRateLimiter, authMiddleware, async (req: express.Request, res: express.Response) => {
+  app.get("/api/genome/search", genomeRateLimiter, authMiddleware, rejectArrayParams("query", "project", "category", "limit"), async (req: express.Request, res: express.Response) => {
     try {
-      if (Array.isArray(req.query.query) || Array.isArray(req.query.project) ||
-          Array.isArray(req.query.category) || Array.isArray(req.query.limit)) {
-        res.status(400).json({ error: "Bad Request: array parameters not supported" });
-        return;
-      }
-
       const query = String(req.query.query || "");
       if (!query) {
         res.status(400).json({ error: "query parameter is required" });

--- a/src/presentation/genomeRoutes.ts
+++ b/src/presentation/genomeRoutes.ts
@@ -49,6 +49,12 @@ export function mountGenomeRoutes(app: express.Application): void {
   // GET /api/genome/search — Semantic search genes
   app.get("/api/genome/search", genomeRateLimiter, authMiddleware, async (req: express.Request, res: express.Response) => {
     try {
+      if (Array.isArray(req.query.query) || Array.isArray(req.query.project) ||
+          Array.isArray(req.query.category) || Array.isArray(req.query.limit)) {
+        res.status(400).json({ error: "Bad Request: array parameters not supported" });
+        return;
+      }
+
       const query = String(req.query.query || "");
       if (!query) {
         res.status(400).json({ error: "query parameter is required" });

--- a/src/presentation/httpServer.ts
+++ b/src/presentation/httpServer.ts
@@ -22,6 +22,7 @@ import {
   unregisterProjectAsync
 } from "../services/projectService.js";
 import { authStorage } from "../utils/context.js";
+import { rejectArrayParams } from "../middleware/validation.js";
 import { registerTools } from "./mcpTools.js";
 import { registerA2ATools } from "./a2a/a2aTools.js";
 import { registerA2AOrchestrationTools } from "./a2aOrchestrationTools.js";
@@ -273,13 +274,8 @@ async function cleanUpEmptyTenantProjectFolder(
 }
 
 // REST API: Remove project and its associated data
-app.delete("/api/projects", authMiddleware, localRateLimiter, async (req, res) => {
+app.delete("/api/projects", authMiddleware, localRateLimiter, rejectArrayParams("projectDir", "force"), async (req, res) => {
   try {
-    if (Array.isArray(req.query.projectDir) || Array.isArray(req.query.force)) {
-      res.status(400).json({ error: "Bad Request: array parameters not supported" });
-      return;
-    }
-
     const auth = authStorage.getStore();
     const tenantId = auth ? auth.uid : undefined;
     
@@ -448,13 +444,8 @@ app.delete("/api/projects", authMiddleware, localRateLimiter, async (req, res) =
 });
 
 // REST API: Get episodic memory (business rules / change logs) for a project
-app.get("/api/projects/memory", authMiddleware, localRateLimiter, async (req, res) => {
+app.get("/api/projects/memory", authMiddleware, localRateLimiter, rejectArrayParams("projectName", "eventType"), async (req, res) => {
   try {
-    if (Array.isArray(req.query.projectName) || Array.isArray(req.query.eventType)) {
-      res.status(400).json({ error: "Bad Request: array parameters not supported" });
-      return;
-    }
-
     const auth = authStorage.getStore();
     if (!auth) {
       return res.status(401).json({ error: "Unauthorized" });
@@ -492,13 +483,8 @@ app.get("/api/projects/memory", authMiddleware, localRateLimiter, async (req, re
 });
 
 // REST API: Get indexing settings for a project
-app.get("/api/projects/settings", authMiddleware, localRateLimiter, async (req, res) => {
+app.get("/api/projects/settings", authMiddleware, localRateLimiter, rejectArrayParams("projectDir", "projectName"), async (req, res) => {
   try {
-    if (Array.isArray(req.query.projectDir) || Array.isArray(req.query.projectName)) {
-      res.status(400).json({ error: "Bad Request: array parameters not supported" });
-      return;
-    }
-
     const auth = authStorage.getStore();
     const tenantId = auth ? auth.uid : undefined;
     
@@ -734,13 +720,8 @@ app.delete("/api/keys/:id", authMiddleware, localRateLimiter, async (req, res) =
 });
 
 // REST API: Get analysis data
-app.get("/api/analysis", authMiddleware, localRateLimiter, async (req, res) => {
+app.get("/api/analysis", authMiddleware, localRateLimiter, rejectArrayParams("projectDir", "project"), async (req, res) => {
   try {
-    if (Array.isArray(req.query.projectDir) || Array.isArray(req.query.project)) {
-      res.status(400).json({ error: "Bad Request: array parameters not supported" });
-      return;
-    }
-
     const projectDir = (req.query.projectDir as string) || (req.query.project as string);
     const loaded = await loadAnalysisAsync(projectDir);
     if (!loaded) return res.status(404).json({ error: "No analysis found" });
@@ -1111,12 +1092,7 @@ app.get("/sse", async (req, res) => {
   }
 });
 
-app.post("/messages", async (req, res) => {
-  if (Array.isArray(req.query.sessionId)) {
-    res.status(400).json({ error: "Bad Request: array parameters not supported" });
-    return;
-  }
-
+app.post("/messages", rejectArrayParams("sessionId"), async (req, res) => {
   let sessionId = req.query.sessionId as string;
   let transport = sessionId ? transports.get(sessionId) : undefined;
 

--- a/src/presentation/httpServer.ts
+++ b/src/presentation/httpServer.ts
@@ -276,7 +276,8 @@ async function cleanUpEmptyTenantProjectFolder(
 app.delete("/api/projects", authMiddleware, localRateLimiter, async (req, res) => {
   try {
     if (Array.isArray(req.query.projectDir) || Array.isArray(req.query.force)) {
-      return res.status(400).json({ error: "Bad Request: array parameters not supported" });
+      res.status(400).json({ error: "Bad Request: array parameters not supported" });
+      return;
     }
 
     const auth = authStorage.getStore();
@@ -450,7 +451,8 @@ app.delete("/api/projects", authMiddleware, localRateLimiter, async (req, res) =
 app.get("/api/projects/memory", authMiddleware, localRateLimiter, async (req, res) => {
   try {
     if (Array.isArray(req.query.projectName) || Array.isArray(req.query.eventType)) {
-      return res.status(400).json({ error: "Bad Request: array parameters not supported" });
+      res.status(400).json({ error: "Bad Request: array parameters not supported" });
+      return;
     }
 
     const auth = authStorage.getStore();
@@ -493,7 +495,8 @@ app.get("/api/projects/memory", authMiddleware, localRateLimiter, async (req, re
 app.get("/api/projects/settings", authMiddleware, localRateLimiter, async (req, res) => {
   try {
     if (Array.isArray(req.query.projectDir) || Array.isArray(req.query.projectName)) {
-      return res.status(400).json({ error: "Bad Request: array parameters not supported" });
+      res.status(400).json({ error: "Bad Request: array parameters not supported" });
+      return;
     }
 
     const auth = authStorage.getStore();
@@ -734,7 +737,8 @@ app.delete("/api/keys/:id", authMiddleware, localRateLimiter, async (req, res) =
 app.get("/api/analysis", authMiddleware, localRateLimiter, async (req, res) => {
   try {
     if (Array.isArray(req.query.projectDir) || Array.isArray(req.query.project)) {
-      return res.status(400).json({ error: "Bad Request: array parameters not supported" });
+      res.status(400).json({ error: "Bad Request: array parameters not supported" });
+      return;
     }
 
     const projectDir = (req.query.projectDir as string) || (req.query.project as string);
@@ -1109,7 +1113,7 @@ app.get("/sse", async (req, res) => {
 
 app.post("/messages", async (req, res) => {
   if (Array.isArray(req.query.sessionId)) {
-    res.status(400).send("Bad Request: array parameters not supported");
+    res.status(400).json({ error: "Bad Request: array parameters not supported" });
     return;
   }
 

--- a/src/presentation/httpServer.ts
+++ b/src/presentation/httpServer.ts
@@ -275,6 +275,10 @@ async function cleanUpEmptyTenantProjectFolder(
 // REST API: Remove project and its associated data
 app.delete("/api/projects", authMiddleware, localRateLimiter, async (req, res) => {
   try {
+    if (Array.isArray(req.query.projectDir) || Array.isArray(req.query.force)) {
+      return res.status(400).json({ error: "Bad Request: array parameters not supported" });
+    }
+
     const auth = authStorage.getStore();
     const tenantId = auth ? auth.uid : undefined;
     
@@ -445,6 +449,10 @@ app.delete("/api/projects", authMiddleware, localRateLimiter, async (req, res) =
 // REST API: Get episodic memory (business rules / change logs) for a project
 app.get("/api/projects/memory", authMiddleware, localRateLimiter, async (req, res) => {
   try {
+    if (Array.isArray(req.query.projectName) || Array.isArray(req.query.eventType)) {
+      return res.status(400).json({ error: "Bad Request: array parameters not supported" });
+    }
+
     const auth = authStorage.getStore();
     if (!auth) {
       return res.status(401).json({ error: "Unauthorized" });
@@ -484,6 +492,10 @@ app.get("/api/projects/memory", authMiddleware, localRateLimiter, async (req, re
 // REST API: Get indexing settings for a project
 app.get("/api/projects/settings", authMiddleware, localRateLimiter, async (req, res) => {
   try {
+    if (Array.isArray(req.query.projectDir) || Array.isArray(req.query.projectName)) {
+      return res.status(400).json({ error: "Bad Request: array parameters not supported" });
+    }
+
     const auth = authStorage.getStore();
     const tenantId = auth ? auth.uid : undefined;
     
@@ -721,6 +733,10 @@ app.delete("/api/keys/:id", authMiddleware, localRateLimiter, async (req, res) =
 // REST API: Get analysis data
 app.get("/api/analysis", authMiddleware, localRateLimiter, async (req, res) => {
   try {
+    if (Array.isArray(req.query.projectDir) || Array.isArray(req.query.project)) {
+      return res.status(400).json({ error: "Bad Request: array parameters not supported" });
+    }
+
     const projectDir = (req.query.projectDir as string) || (req.query.project as string);
     const loaded = await loadAnalysisAsync(projectDir);
     if (!loaded) return res.status(404).json({ error: "No analysis found" });
@@ -1092,6 +1108,11 @@ app.get("/sse", async (req, res) => {
 });
 
 app.post("/messages", async (req, res) => {
+  if (Array.isArray(req.query.sessionId)) {
+    res.status(400).send("Bad Request: array parameters not supported");
+    return;
+  }
+
   let sessionId = req.query.sessionId as string;
   let transport = sessionId ? transports.get(sessionId) : undefined;
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Express natively parses multiple identical query parameters (e.g., `?id=1&id=2`) into an array instead of a string. Route endpoints were type-casting `req.query.*` values as `string` without runtime verification, and passing those values down to database layers or `.trim()` methods, creating Denial of Service (DoS) conditions and risking parameter injection attacks.
🎯 **Impact:** An attacker could craft multi-parameter URLs causing internal 500 errors (DoS via unhandled exceptions) or bypass simplistic regex validations before backend database evaluation.
🔧 **Fix:** Inserted runtime validation using `Array.isArray()` across all affected routes. If an array is detected in `req.query` parameters expected to be primitives, the endpoint immediately halts execution and returns a `400 Bad Request`.
✅ **Verification:** Verified that array bounds are correctly intercepted across presentation logic, and all regression test suites pass (`pnpm test`, `pnpm run build`, and `pnpm lint`).

---
*PR created automatically by Jules for task [3545799732713618685](https://jules.google.com/task/3545799732713618685) started by @giauphan*