### PR TITLE
feat: auto-extract genome genes and add verified_solution_search tool

### DIFF
--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -1522,6 +1522,65 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
   a2a("get_gene", "Get a specific gene by ID from the Genome.", ["geneId"]);
   a2a("scan_immune_genes", "CRISPR immune scan: check problem against known failures.", ["problem", "project"]);
   a2a("save_immune_gene", "Record a failure as an immune gene.", ["problem", "failure", "prevention", "project"]);
+  // ── Strict solution search with verified system-design codebase flow ──
+  server.tool(
+    "verified_solution_search",
+    "Strict solution search: find genome genes for a problem, trace the codebase feature flow that implements them, and verify the flow exists. Returns verified: true only when both a gene match and a real code flow are found.",
+    {
+      query: z.string().min(1).max(2000).describe("Problem or task description to search solutions for"),
+      project: z.string().optional().describe("Project name or path"),
+      keyword: z.string().optional().describe("Feature keyword used to trace the codebase flow (defaults to query)"),
+      limit: z.number().int().min(1).max(20).optional().describe("Max genes to return (default 5)"),
+    },
+    mcpHandler(async ({ query, project, keyword, limit }) => {
+      const auth = await checkAuth();
+      return authStorage.run(auth, async () => {
+        await logActivity(auth, "verified_solution_search", { query, project, keyword });
+        const loaded = project ? await loadAnalysisAsync(project) : null;
+        const projectName = loaded ? loaded.projectName : (project || "global");
+
+        const traceKeyword = keyword || query;
+        const minGenes = limit ?? 5;
+
+        // Strict gate 1: genome relevance.
+        const genes = await GenomeService.searchGenes(query, { project: projectName, limit: minGenes });
+        const relevantGenes = genes.filter((g) => g.confidence >= 0.5 && g.score >= 0.3);
+
+        // Strict gate 2: real codebase flow from the analysis graph.
+        const kw = traceKeyword.toLowerCase();
+        const flowNodes = loaded
+          ? loaded.analysis.graph.nodes.filter((n) =>
+              n.label.toLowerCase().includes(kw) ||
+              String(n.filePath || "").toLowerCase().includes(kw)
+            )
+          : [];
+        const flowNodeIds = new Set(flowNodes.map((n) => n.id));
+        const flowLinks = loaded
+          ? loaded.analysis.graph.links.filter((l) => flowNodeIds.has(l.source) && flowNodeIds.has(l.target))
+          : [];
+
+        const verified = relevantGenes.length > 0 && flowNodes.length > 0;
+        const result = {
+          project: projectName,
+          query,
+          keyword: traceKeyword,
+          verified,
+          verification: verified
+            ? "VERIFIED: genome solution matched and codebase flow traced"
+            : "UNVERIFIED: no confident gene match or no codebase flow nodes found",
+          genes: relevantGenes.map((g) => ({ id: g.id, name: g.name, category: g.category, score: g.score, confidence: g.confidence, solution: g.solution })),
+          codebaseFlow: {
+            entryPoints: flowNodes.slice(0, 10).map((n) => ({ id: n.id, label: n.label, type: n.type, filePath: n.filePath, line: n.line })),
+            internalLinks: flowLinks.slice(0, 20).map((l) => ({ source: l.source, target: l.target, type: l.type })),
+            nodeCount: flowNodes.length,
+            linkCount: flowLinks.length,
+          },
+        };
+        return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+      });
+    })
+  );
+  a2a("verified_solution_search", "Strict verified solution search over Genome and codebase flow.", ["query", "project", "keyword", "limit"]);
   // ── Auto-Sync Tool ─────────────────────────────────────────
   server.tool("sync_skills", "Auto-sync Hermes AI skills into CodeAtlas Genome.", {}, async () => {
     const auth = await checkAuth();

--- a/src/services/dreamPipelineService.ts
+++ b/src/services/dreamPipelineService.ts
@@ -10,6 +10,7 @@ import { authStorage } from "../utils/context.js";
 import { DreamingService, type DreamMemoryType } from "./dreamingService.js";
 import { summarizeConversationForDreams } from "./llmService.js";
 import { ConsolidationEngine, type ConsolidationReport } from "./consolidationEngine.js";
+import { GenomeService } from "./genomeService.js";
 
 export interface DailyPipelineOptions {
   project?: string;
@@ -42,6 +43,7 @@ export interface SessionIngestionResult {
   provider: string;
   dreamsExtracted: number;
   noiseBlocked: number;
+  genesSaved: number;
   dreams: Array<{ id: string; memory_type: string; content: string }>;
   startedAt: string;
   completedAt: string;
@@ -180,6 +182,7 @@ export class DreamPipelineService {
         provider,
         dreamsExtracted: 0,
         noiseBlocked: 0,
+        genesSaved: 0,
         dreams: [],
         startedAt,
         completedAt,
@@ -208,9 +211,26 @@ export class DreamPipelineService {
       }
     }
 
+    let genesSaved = 0;
+    for (const savedDream of savedDreams) {
+      try {
+        await authStorage.run(auth, () =>
+          GenomeService.extractGene({
+            sourceType: "dream",
+            sourceId: savedDream.id,
+            project,
+            autoExtract: true
+          })
+        );
+        genesSaved++;
+      } catch (err) {
+        logger.error(`[Dreaming Pipeline] Strict genome auto-save failed for dream ${savedDream.id}:`, err instanceof Error ? err.message : String(err));
+      }
+    }
+
     const totalMs = Date.now() - ingestStartTime;
     const completedAt = new Date().toISOString();
-    logger.info(`[Dreaming Pipeline] [${completedAt}] Session="${sessId}" ingestion COMPLETED in ${totalMs}ms: saved=${savedDreams.length}, noise_blocked=${skipped.length} for project="${project}" provider="${provider}"`);
+    logger.info(`[Dreaming Pipeline] [${completedAt}] Session="${sessId}" ingestion COMPLETED in ${totalMs}ms: saved=${savedDreams.length}, noise_blocked=${skipped.length}, genes_saved=${genesSaved} for project="${project}" provider="${provider}"`);
 
     return {
       success: true,
@@ -220,6 +240,7 @@ export class DreamPipelineService {
       provider,
       dreamsExtracted: savedDreams.length,
       noiseBlocked: skipped.length,
+      genesSaved,
       dreams: savedDreams,
       startedAt,
       completedAt,

--- a/src/services/llmService.ts
+++ b/src/services/llmService.ts
@@ -173,7 +173,10 @@ export async function loadContextAtSessionStart(
       return "";
     }
 
-    const parts: string[] = ["\n# 🧠 Context from Previous Sessions\n"];
+    const parts: string[] = [];
+    if (cleanDreams.length > 0) {
+      parts.push("\n# 🧠 Context from Previous Sessions\n");
+    }
     for (const dream of cleanDreams) {
       const d = dream as Record<string, unknown>;
       const memoryType = String(d.memoryType ?? d.memory_type ?? d.MEMORY_TYPE ?? "DREAM");

--- a/src/services/llmService.ts
+++ b/src/services/llmService.ts
@@ -1,5 +1,6 @@
 import { logger } from "../utils/logger.js";
 import { DreamingService } from "./dreamingService.js";
+import { GenomeService } from "./genomeService.js";
 import { checkNoiseBlocklist } from "./noiseBlocklist.js";
 import { countMatching } from "../utils/array.js";
 
@@ -130,14 +131,33 @@ export async function loadContextAtSessionStart(
       10
     );
 
-    if (!dreams || dreams.length === 0) {
+    // Strict genome auto-load: relevance-gated genes + immune context for the
+    // explicit task only. Never fires without a non-empty task.
+    const strictTask = String(task || "").trim();
+    let genes: Awaited<ReturnType<typeof GenomeService.searchGenes>> = [];
+    let immuneContext = "";
+    if (strictTask.length > 0) {
+      try {
+        genes = await GenomeService.searchGenes(strictTask, { project, limit: 5 });
+        genes = genes.filter((g) => g.confidence >= 0.5 && g.score >= 0.3);
+      } catch (err) {
+        logger.error(`[Memory Loading] Genome auto-load failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      try {
+        immuneContext = (await GenomeService.buildImmuneContext(strictTask, project)) || "";
+      } catch (err) {
+        logger.error(`[Memory Loading] Immune context failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    if ((!dreams || dreams.length === 0) && genes.length === 0 && !immuneContext) {
       return "";
     }
 
     const cleanDreams: Array<{ memoryType: string; content: string; importance: number }> = [];
-    const dreamsLen = dreams.length;
+    const dreamsLen = dreams?.length ?? 0;
     for (let i = 0; i < dreamsLen; i++) {
-      const dream = dreams[i];
+      const dream = dreams![i];
       const row = dream as Record<string, unknown>;
       const content = String(row.content ?? row.CONTENT ?? "");
       if (!checkNoiseBlocklist(content).isNoise) {
@@ -149,7 +169,7 @@ export async function loadContextAtSessionStart(
     if (blockedCount > 0) {
       logger.info(`[Memory Loading] Inject-gate filtered ${blockedCount} noisy dream(s)`);
     }
-    if (cleanDreams.length === 0) {
+    if (cleanDreams.length === 0 && genes.length === 0 && !immuneContext) {
       return "";
     }
 
@@ -164,11 +184,27 @@ export async function loadContextAtSessionStart(
       parts.push("");
     }
 
+    if (genes.length > 0) {
+      parts.push("\n# 🧬 Verified Genome Patterns\n");
+      for (const gene of genes) {
+        parts.push(`### ${gene.name} (category: ${gene.category}, confidence: ${gene.confidence.toFixed(2)})`);
+        if (gene.problem) {
+          parts.push(`Problem: ${gene.problem}`);
+        }
+        parts.push(`Solution: ${gene.solution}`);
+        parts.push("");
+      }
+    }
+
+    if (immuneContext) {
+      parts.push(immuneContext);
+    }
+
     const context = parts.join("\n");
 
     // Log context loading event
     const fs = await import('node:fs');
-    const logEntry = `[${new Date().toISOString()}] LOADED: session=${sessionId}, project=${project}, dreams=${dreams.length}\n`;
+    const logEntry = `[${new Date().toISOString()}] LOADED: session=${sessionId}, project=${project}, dreams=${dreams?.length ?? 0}, genes=${genes.length}, immune=${immuneContext ? 1 : 0}\n`;
     try {
       await fs.promises.appendFile('/tmp/memory_loading.log', logEntry);
     } catch (err) {

--- a/tests/unit/dream-pipeline-service.test.ts
+++ b/tests/unit/dream-pipeline-service.test.ts
@@ -42,10 +42,17 @@ function safeMockModule(specifier: string, mockObj: Record<string, unknown>) {
 const mockSaveDreamMemory = mock.fn();
 const mockSummarizeConversation = mock.fn();
 const mockConsolidationRun = mock.fn();
+const mockExtractGene = mock.fn();
 
 safeMockModule(path.join(srcDir, 'services/dreamingService.js'), {
   DreamingService: {
     saveDreamMemory: mockSaveDreamMemory,
+  },
+});
+
+safeMockModule(path.join(srcDir, 'services/genomeService.js'), {
+  GenomeService: {
+    extractGene: mockExtractGene,
   },
 });
 
@@ -122,11 +129,16 @@ describe('DreamPipelineService', () => {
   });
 
   describe('runSessionIngestion', () => {
+    beforeEach(() => {
+      mockExtractGene.mock.resetCalls();
+    });
+
     test('processes transcript, saves dreams, and returns duration', async () => {
       mockSummarizeConversation.mock.mockImplementation(async () => [
         { memoryType: 'KNOWLEDGE', content: 'Design systems scale cleanly', importance: 8 },
       ]);
       mockSaveDreamMemory.mock.mockImplementation(async () => 'mem-101');
+      mockExtractGene.mock.mockImplementation(async () => 'gene-101');
 
       const result = await DreamPipelineService.runSessionIngestion({
         content: '[USER] We refactored the pipeline into a separate service.',
@@ -145,6 +157,69 @@ describe('DreamPipelineService', () => {
       assert.strictEqual(result.dreams.length, 1);
       assert.strictEqual(result.dreams[0].id, 'mem-101');
       assert.ok(result.durationMs >= 0);
+    });
+
+    test('auto-saves a genome gene for each saved dream', async () => {
+      mockSummarizeConversation.mock.mockImplementation(async () => [
+        { memoryType: 'PATTERN', content: 'Repository adapters isolate SQL dialects', importance: 7 },
+      ]);
+      mockSaveDreamMemory.mock.mockImplementation(async () => 'mem-201');
+      mockExtractGene.mock.mockImplementation(async () => 'gene-201');
+
+      const result = await DreamPipelineService.runSessionIngestion({
+        content: '[ASSISTANT] The repository adapter isolates SQL dialects behind one interface.',
+        sessionId: 'sess-gene',
+        project: 'codeatlas-platform',
+        provider: 'claude',
+      });
+
+      assert.strictEqual(result.genesSaved, 1);
+      assert.strictEqual(mockExtractGene.mock.callCount(), 1);
+      const call = mockExtractGene.mock.calls[0].arguments[0];
+      assert.strictEqual(call.sourceType, 'dream');
+      assert.strictEqual(call.sourceId, 'mem-201');
+      assert.strictEqual(call.project, 'codeatlas-platform');
+    });
+
+    test('auto-save failure does not fail ingestion', async () => {
+      mockSummarizeConversation.mock.mockImplementation(async () => [
+        { memoryType: 'KNOWLEDGE', content: 'Embedding cache prevents duplicate API calls', importance: 6 },
+      ]);
+      mockSaveDreamMemory.mock.mockImplementation(async () => 'mem-301');
+      mockExtractGene.mock.mockImplementation(async () => {
+        throw new Error('embedding provider unavailable');
+      });
+
+      const result = await DreamPipelineService.runSessionIngestion({
+        content: '[USER] We cached embeddings so repeated queries do not hit the API.',
+        sessionId: 'sess-fail',
+        project: 'codeatlas-platform',
+        provider: 'claude',
+      });
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.dreamsExtracted, 1);
+      assert.strictEqual(result.genesSaved, 0);
+    });
+
+    test('skips gene auto-save for noise-blocked dreams', async () => {
+      mockSummarizeConversation.mock.mockImplementation(async () => [
+        { memoryType: 'KNOWLEDGE', content: 'This is noise', importance: 1 },
+      ]);
+      mockSaveDreamMemory.mock.mockImplementation(async () => '__noise_blocked__');
+      mockExtractGene.mock.mockImplementation(async () => 'gene-never');
+
+      const result = await DreamPipelineService.runSessionIngestion({
+        content: '[USER] This is noise',
+        sessionId: 'sess-noise',
+        project: 'codeatlas-platform',
+        provider: 'claude',
+      });
+
+      assert.strictEqual(result.dreamsExtracted, 0);
+      assert.strictEqual(result.noiseBlocked, 1);
+      assert.strictEqual(result.genesSaved, 0);
+      assert.strictEqual(mockExtractGene.mock.callCount(), 0);
     });
   });
 

--- a/tests/unit/llm-service.test.ts
+++ b/tests/unit/llm-service.test.ts
@@ -72,6 +72,9 @@ function safeMockModule(specifier: string, mockObj: Record<string, unknown>) {
 const mockQueryDreamMemories = mock.fn();
 const mockSaveDreamMemory = mock.fn();
 const mockCheckNoiseBlocklist = mock.fn();
+const mockSearchGenes = mock.fn();
+const mockBuildImmuneContext = mock.fn();
+
 const mockLogger = {
   info: mock.fn(),
   warn: mock.fn(),
@@ -83,6 +86,13 @@ safeMockModule(path.join(srcDir, 'services/dreamingService.js'), {
   DreamingService: {
     queryDreamMemories: mockQueryDreamMemories,
     saveDreamMemory: mockSaveDreamMemory,
+  },
+});
+
+safeMockModule(path.join(srcDir, 'services/genomeService.js'), {
+  GenomeService: {
+    searchGenes: mockSearchGenes,
+    buildImmuneContext: mockBuildImmuneContext,
   },
 });
 
@@ -112,11 +122,15 @@ describe('llmService Unit Tests', () => {
     mockQueryDreamMemories.mock.resetCalls();
     mockSaveDreamMemory.mock.resetCalls();
     mockCheckNoiseBlocklist.mock.resetCalls();
+    mockSearchGenes.mock.resetCalls();
+    mockBuildImmuneContext.mock.resetCalls();
     mockLogger.info.mock.resetCalls();
     mockLogger.warn.mock.resetCalls();
     mockLogger.error.mock.resetCalls();
     mockLogger.debug.mock.resetCalls();
     mockCheckNoiseBlocklist.mock.mockImplementation(() => ({ isNoise: false }));
+    mockSearchGenes.mock.mockImplementation(async () => []);
+    mockBuildImmuneContext.mock.mockImplementation(async () => '');
   });
 
   describe('summarizeConversationForDreams', () => {
@@ -239,6 +253,93 @@ describe('llmService Unit Tests', () => {
 
       const context = await loadContextAtSessionStart('sess-11', 'my-app', 'task-err');
       assert.strictEqual(context, '');
+    });
+
+    test('includes high-confidence genes and immune context for non-empty task', async () => {
+      mockQueryDreamMemories.mock.mockImplementation(async () => []);
+      mockSearchGenes.mock.mockImplementation(async () => [
+        {
+          id: 'gene-1',
+          name: 'integration-db-gene',
+          category: 'immune',
+          problem: 'mocked database tests mask production migration failures',
+          solution: 'integration tests must hit a real database',
+          confidence: 0.8,
+          score: 0.6,
+        },
+        {
+          id: 'gene-2',
+          name: 'weak-gene',
+          category: 'pattern',
+          problem: 'weak problem',
+          solution: 'weak solution',
+          confidence: 0.4,
+          score: 0.6,
+        },
+        {
+          id: 'gene-3',
+          name: 'low-score-gene',
+          category: 'lesson',
+          problem: 'low score problem',
+          solution: 'low score solution',
+          confidence: 0.9,
+          score: 0.1,
+        },
+      ]);
+      mockBuildImmuneContext.mock.mockImplementation(async () => '# ⚠️ Immune System\n- Prevent recurrence of failure gene-1');
+
+      const context = await loadContextAtSessionStart('sess-12', 'my-app', 'database migration failure');
+
+      assert.strictEqual(mockSearchGenes.mock.calls.length, 1);
+      assert.strictEqual(mockSearchGenes.mock.calls[0].arguments[0], 'database migration failure');
+      assert.strictEqual(mockBuildImmuneContext.mock.calls.length, 1);
+      assert.strictEqual(mockBuildImmuneContext.mock.calls[0].arguments[0], 'database migration failure');
+
+      assert.ok(context.includes('# 🧬 Verified Genome Patterns'));
+      assert.ok(context.includes('integration-db-gene'));
+      assert.ok(context.includes('integration tests must hit a real database'));
+      assert.ok(!context.includes('weak-gene'));
+      assert.ok(!context.includes('low-score-gene'));
+      assert.ok(context.includes('# ⚠️ Immune System'));
+    });
+
+    test('does not call genome services when task is empty', async () => {
+      mockQueryDreamMemories.mock.mockImplementation(async () => []);
+
+      const empty1 = await loadContextAtSessionStart('sess-13', 'my-app', '');
+      const empty2 = await loadContextAtSessionStart('sess-14', 'my-app', '   ');
+      const empty3 = await loadContextAtSessionStart('sess-15', 'my-app', undefined as unknown as string);
+
+      assert.strictEqual(mockSearchGenes.mock.calls.length, 0);
+      assert.strictEqual(mockBuildImmuneContext.mock.calls.length, 0);
+      assert.strictEqual(empty1, '');
+      assert.strictEqual(empty2, '');
+      assert.strictEqual(empty3, '');
+    });
+
+    test('genome failure does not break dream-only context', async () => {
+      mockQueryDreamMemories.mock.mockImplementation(async () => [
+        {
+          id: 'mem-3',
+          memory_type: 'PREFERENCE',
+          content: 'Keep dream context loading intact',
+          importance: 7,
+        },
+      ]);
+      mockSearchGenes.mock.mockImplementation(async () => {
+        throw new Error('Vector index unavailable');
+      });
+      mockBuildImmuneContext.mock.mockImplementation(async () => {
+        throw new Error('Immune scan unavailable');
+      });
+
+      const context = await loadContextAtSessionStart('sess-16', 'my-app', 'auth fix');
+
+      assert.ok(context.includes('PREFERENCE'));
+      assert.ok(context.includes('Keep dream context loading intact'));
+      assert.ok(!context.includes('# 🧬 Verified Genome Patterns'));
+      assert.ok(!context.includes('Immune System'));
+      assert.strictEqual(mockLogger.error.mock.calls.length, 2);
     });
   });
 

--- a/tests/unit/llm-service.test.ts
+++ b/tests/unit/llm-service.test.ts
@@ -303,6 +303,27 @@ describe('llmService Unit Tests', () => {
       assert.ok(context.includes('# ⚠️ Immune System'));
     });
 
+    test('does not emit empty dream header when only genes or immune context are present', async () => {
+      mockQueryDreamMemories.mock.mockImplementation(async () => []);
+      mockSearchGenes.mock.mockImplementation(async () => [
+        {
+          id: 'gene-1',
+          name: 'isolated-gene',
+          category: 'pattern',
+          problem: 'isolated problem',
+          solution: 'isolated solution',
+          confidence: 0.8,
+          score: 0.6,
+        },
+      ]);
+      mockBuildImmuneContext.mock.mockImplementation(async () => '');
+
+      const context = await loadContextAtSessionStart('sess-no-dreams', 'my-app', 'some task');
+
+      assert.ok(context.includes('# 🧬 Verified Genome Patterns'));
+      assert.ok(!context.includes('# 🧠 Context from Previous Sessions'), 'Must not emit empty dream section header when dreams are empty');
+    });
+
     test('does not call genome services when task is empty', async () => {
       mockQueryDreamMemories.mock.mockImplementation(async () => []);
 


### PR DESCRIPTION
## Summary

Add automatic genome extraction to the dream session ingestion pipeline and introduce the `verified_solution_search` MCP tool.

## Motivation

Automating genome extraction links dream learnings to reusable patterns automatically. The new MCP tool enables AI agents to query verified patterns alongside execution flow inside the current analyzed project.

## Changes

- Extract confident genome genes from saved dream memories inside `runSessionIngestion`.
- Track `genesSaved` telemetry metrics.
- Add `verified_solution_search` MCP tool with cross-checks for genome genes and real AST flow nodes.
- Prevent emitting empty `# Context from Previous Sessions` sections when only genome vectors are present.
- Ensure `GenomeService.searchGenes` queries execute within the authenticated tenant boundary via `authStorage.run`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [x] Test improvement

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm test` passes
- [ ] Dashboard builds (`cd dashboard && pnpm run build`) if dashboard touched
- [x] Tests added for new behavior
- [ ] Documentation updated (`README.md`, `docs/`, `CHANGELOG.md`) if user-visible change
- [x] No secrets, credentials, or personal data in diff
- [x] No `any` types — used `unknown` + type guards
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, etc.)

## Test plan

- `pnpm run typecheck`
- `pnpm run build`
- `pnpm test` — 262 passing
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)