### PR TITLE
⚡ Bolt: Replace O(N^2) graph filters with O(N) adjacency maps

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,49 @@
+1. **Identify the performance bottleneck:**
+   In `src/presentation/mcpTools.ts`, within the `trace_feature_flow` tool (around lines 1180-1250), there is a bottleneck when building the `executionOrder` array.
+   Inside the topological sort loop (and the subsequent loop for remaining nodes), the code does:
+   ```typescript
+   const callsTo = dedupLinks
+     .filter((l) => l.source === current)
+     .map((l) => nodeNameMap.get(l.target) || l.target);
+   const calledBy = dedupLinks
+     .filter((l) => l.target === current)
+     .map((l) => nodeNameMap.get(l.source) || l.source);
+   ```
+   This iterates over `dedupLinks` (an array) for every node in `traceNodes`. This makes it an O(V * E) operation (where V is the number of nodes and E is the number of edges), which is basically O(N^2) for dense graphs.
+
+2. **Optimize with O(N) preprocessing:**
+   We can pre-calculate the `callsTo` and `calledBy` relationships for all nodes in a single pass over `dedupLinks`.
+   ```typescript
+   // Pre-calculate relationship arrays to avoid O(V*E) nested loops
+   const callsToMap = new Map<string, string[]>();
+   const calledByMap = new Map<string, string[]>();
+
+   for (const link of dedupLinks) {
+     const sourceName = nodeNameMap.get(link.source) || link.source;
+     const targetName = nodeNameMap.get(link.target) || link.target;
+
+     if (!callsToMap.has(link.source)) callsToMap.set(link.source, []);
+     callsToMap.get(link.source)!.push(targetName);
+
+     if (!calledByMap.has(link.target)) calledByMap.set(link.target, []);
+     calledByMap.get(link.target)!.push(sourceName);
+   }
+   ```
+   Then inside the loops, we can just do O(1) lookups:
+   ```typescript
+   const callsTo = callsToMap.get(current) || [];
+   const calledBy = calledByMap.get(current) || [];
+   ```
+
+3. **Update `.jules/bolt.md`:**
+   Add a learning about replacing nested O(N^2) `.filter()` loops inside graphing algorithms with O(N) adjacency maps.
+
+4. **Verify the optimization:**
+   - Pre-commit instructions for formatting and testing.
+   - Wait for pre-commit instructions response.
+   - Fix any failing tests or linting errors.
+
+5. **Submit the PR:**
+   Submit the changes using the required PR format for Bolt:
+   Title: "⚡ Bolt: [performance improvement]"
+   Description containing: What, Why, Impact, and Measurement.

--- a/src/presentation/mcpTools.ts
+++ b/src/presentation/mcpTools.ts
@@ -1180,12 +1180,27 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
         calledBy: string[];
       }> = [];
 
+      // ⚡ Bolt Optimization: Pre-calculate relationship arrays to avoid O(V*E) nested loops
+      // Replaces O(N^2) array filtering inside the topological sort with O(1) map lookups.
       const inDegree = new Map<string, number>();
+      const callsToMap = new Map<string, string[]>();
+      const calledByMap = new Map<string, string[]>();
+
       for (const node of traceNodes) {
         inDegree.set(node.id, 0);
       }
+
       for (const link of dedupLinks) {
         inDegree.set(link.target, (inDegree.get(link.target) || 0) + 1);
+
+        const sourceName = nodeNameMap.get(link.source) || link.source;
+        const targetName = nodeNameMap.get(link.target) || link.target;
+
+        if (!callsToMap.has(link.source)) callsToMap.set(link.source, []);
+        callsToMap.get(link.source)!.push(targetName);
+
+        if (!calledByMap.has(link.target)) calledByMap.set(link.target, []);
+        calledByMap.get(link.target)!.push(sourceName);
       }
 
       const queue: string[] = [];
@@ -1202,12 +1217,8 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
 
         const node = nodeMap.get(current);
         if (node) {
-          const callsTo = dedupLinks
-            .filter((l) => l.source === current)
-            .map((l) => nodeNameMap.get(l.target) || l.target);
-          const calledBy = dedupLinks
-            .filter((l) => l.target === current)
-            .map((l) => nodeNameMap.get(l.source) || l.source);
+          const callsTo = callsToMap.get(current) || [];
+          const calledBy = calledByMap.get(current) || [];
 
           executionOrder.push({
             step: step++,
@@ -1233,12 +1244,8 @@ export function registerTools(server: McpServer, sessionAuth?: { tier: string; u
 
       for (const node of traceNodes) {
         if (!ordered.has(node.id)) {
-          const callsTo = dedupLinks
-            .filter((l) => l.source === node.id)
-            .map((l) => nodeNameMap.get(l.target) || l.target);
-          const calledBy = dedupLinks
-            .filter((l) => l.target === node.id)
-            .map((l) => nodeNameMap.get(l.source) || l.source);
+          const callsTo = callsToMap.get(node.id) || [];
+          const calledBy = calledByMap.get(node.id) || [];
 
           executionOrder.push({
             step: step++,


### PR DESCRIPTION
💡 What: Replaced nested `.filter()` and `.map()` calls within graph traversal iterations with pre-calculated O(1) Map lookups for `callsTo` and `calledBy` arrays in `src/presentation/mcpTools.ts`.
🎯 Why: The original logic in `trace_feature_flow` used `dedupLinks.filter` for every node in the graph inside a topological sort, leading to O(V * E) performance (which scales quadratically on dense graphs).
📊 Impact: Considerably faster graph traversal and generation of Mermaid charts, significantly reducing the algorithmic time complexity of adjacency lookups from O(V*E) to O(V+E).
🔬 Measurement: Verify by executing large graph resolutions using the `trace_feature_flow` MCP tool. `CI=true pnpm test` was executed successfully indicating no logic breakages or functionality regressions.

---
*PR created automatically by Jules for task [6687100868799779405](https://jules.google.com/task/6687100868799779405) started by @giauphan*