### PR TITLE
⚡ Bolt: Make dreaming memory access count bumps non-blocking

### DIFF
--- a/src/presentation/httpServer.ts
+++ b/src/presentation/httpServer.ts
@@ -1227,8 +1227,13 @@ export function startHttpServer(port: number, retries = 5): Promise<void> {
           }
 
           // Define shutdown handler
-          const shutdown = (signal: string, server: Server) => {
+          const shutdown = async (signal: string, server: Server) => {
             logger.info(`${signal} received: Closing HTTP server...`);
+            const { DreamingService } = await import('../services/dreamingService.js');
+            if (DreamingService.activeBackgroundTasks.size > 0) {
+              logger.info(`Waiting for ${DreamingService.activeBackgroundTasks.size} pending database writes to complete...`);
+              await Promise.allSettled(Array.from(DreamingService.activeBackgroundTasks));
+            }
             server.close(() => {
               logger.info('HTTP server closed');
               process.exit(0);

--- a/src/presentation/httpServer.ts
+++ b/src/presentation/httpServer.ts
@@ -1229,14 +1229,22 @@ export function startHttpServer(port: number, retries = 5): Promise<void> {
           // Define shutdown handler
           const shutdown = async (signal: string, server: Server) => {
             logger.info(`${signal} received: Closing HTTP server...`);
-            const { DreamingService } = await import('../services/dreamingService.js');
-            if (DreamingService.activeBackgroundTasks.size > 0) {
-              logger.info(`Waiting for ${DreamingService.activeBackgroundTasks.size} pending database writes to complete...`);
-              await Promise.allSettled(Array.from(DreamingService.activeBackgroundTasks));
-            }
-            server.close(() => {
+            server.close(async () => {
               logger.info('HTTP server closed');
-              process.exit(0);
+              try {
+                const { DreamingService } = await import('../services/dreamingService.js');
+                if (DreamingService.activeBackgroundTasks.size > 0) {
+                  logger.info(`Waiting for ${DreamingService.activeBackgroundTasks.size} pending database writes to complete...`);
+                  await Promise.race([
+                    Promise.allSettled(Array.from(DreamingService.activeBackgroundTasks)),
+                    new Promise(r => setTimeout(r, 5000))
+                  ]);
+                }
+              } catch (err) {
+                logger.error('Error during graceful shutdown:', err instanceof Error ? err.message : String(err));
+              } finally {
+                process.exit(0);
+              }
             });
           };
 

--- a/src/presentation/httpServer.ts
+++ b/src/presentation/httpServer.ts
@@ -1227,12 +1227,18 @@ export function startHttpServer(port: number, retries = 5): Promise<void> {
           }
 
           // Define shutdown handler
+          let isShuttingDown = false;
           const shutdown = (signal: string, server: Server) => {
+            if (isShuttingDown) return;
+            isShuttingDown = true;
             logger.info(`${signal} received: Closing HTTP server...`);
 
+            type ModernServer = Server & { closeIdleConnections?: () => void, closeAllConnections?: () => void };
+            const mServer = server as ModernServer;
+
             // Kill idle keep-alive connections first (Node >= 18.2)
-            if (typeof (server as any).closeIdleConnections === 'function') {
-              (server as any).closeIdleConnections();
+            if (typeof mServer.closeIdleConnections === 'function') {
+              mServer.closeIdleConnections();
             }
 
             server.close(async () => {
@@ -1249,8 +1255,8 @@ export function startHttpServer(port: number, retries = 5): Promise<void> {
 
             // Hard exit fallback if `server.close` hangs (e.g. active connections not resolving)
             setTimeout(() => {
-              if (typeof (server as any).closeAllConnections === 'function') {
-                (server as any).closeAllConnections();
+              if (typeof mServer.closeAllConnections === 'function') {
+                mServer.closeAllConnections();
               }
               logger.error('Graceful shutdown timed out after 10s, forcing exit.');
               process.exit(1);

--- a/src/presentation/httpServer.ts
+++ b/src/presentation/httpServer.ts
@@ -1227,25 +1227,28 @@ export function startHttpServer(port: number, retries = 5): Promise<void> {
           }
 
           // Define shutdown handler
-          const shutdown = async (signal: string, server: Server) => {
+          const shutdown = (signal: string, server: Server) => {
             logger.info(`${signal} received: Closing HTTP server...`);
+
+            // Wait a grace period for active requests to finish, or force close
+            server.closeAllConnections(); // For Node >= 18.2 to close keep-alive
             server.close(async () => {
               logger.info('HTTP server closed');
               try {
                 const { DreamingService } = await import('../services/dreamingService.js');
-                if (DreamingService.activeBackgroundTasks.size > 0) {
-                  logger.info(`Waiting for ${DreamingService.activeBackgroundTasks.size} pending database writes to complete...`);
-                  await Promise.race([
-                    Promise.allSettled(Array.from(DreamingService.activeBackgroundTasks)),
-                    new Promise(r => setTimeout(r, 5000))
-                  ]);
-                }
+                await DreamingService.waitForBackgroundTasks(5000);
               } catch (err) {
                 logger.error('Error during graceful shutdown:', err instanceof Error ? err.message : String(err));
               } finally {
                 process.exit(0);
               }
             });
+
+            // Hard exit fallback if `server.close` hangs (e.g. idle connections missing `closeAllConnections` on older node)
+            setTimeout(() => {
+              logger.error('Graceful shutdown timed out, forcing exit.');
+              process.exit(1);
+            }, 6000).unref();
           };
 
           // Register handlers once

--- a/src/presentation/httpServer.ts
+++ b/src/presentation/httpServer.ts
@@ -1230,8 +1230,11 @@ export function startHttpServer(port: number, retries = 5): Promise<void> {
           const shutdown = (signal: string, server: Server) => {
             logger.info(`${signal} received: Closing HTTP server...`);
 
-            // Wait a grace period for active requests to finish, or force close
-            server.closeAllConnections(); // For Node >= 18.2 to close keep-alive
+            // Kill idle keep-alive connections first (Node >= 18.2)
+            if (typeof (server as any).closeIdleConnections === 'function') {
+              (server as any).closeIdleConnections();
+            }
+
             server.close(async () => {
               logger.info('HTTP server closed');
               try {
@@ -1244,11 +1247,14 @@ export function startHttpServer(port: number, retries = 5): Promise<void> {
               }
             });
 
-            // Hard exit fallback if `server.close` hangs (e.g. idle connections missing `closeAllConnections` on older node)
+            // Hard exit fallback if `server.close` hangs (e.g. active connections not resolving)
             setTimeout(() => {
-              logger.error('Graceful shutdown timed out, forcing exit.');
+              if (typeof (server as any).closeAllConnections === 'function') {
+                (server as any).closeAllConnections();
+              }
+              logger.error('Graceful shutdown timed out after 10s, forcing exit.');
               process.exit(1);
-            }, 6000).unref();
+            }, 10000).unref();
           };
 
           // Register handlers once

--- a/src/services/dreamingService.ts
+++ b/src/services/dreamingService.ts
@@ -78,18 +78,22 @@ export class DreamingService {
    * Logs a warning if any tasks are still pending after the timeout.
    */
   static async waitForBackgroundTasks(timeoutMs: number = 5000): Promise<void> {
-    if (DreamingService.activeBackgroundTasks.size === 0) return;
+    while (DreamingService.activeBackgroundTasks.size > 0) {
+      logger.info(`Waiting for ${DreamingService.activeBackgroundTasks.size} pending database writes to complete...`);
 
-    logger.info(`Waiting for ${DreamingService.activeBackgroundTasks.size} pending database writes to complete...`);
+      let settled = false;
+      const settlePromise = Promise.allSettled(Array.from(DreamingService.activeBackgroundTasks)).then(() => { settled = true; });
+      const timeoutPromise = new Promise(resolve => setTimeout(resolve, timeoutMs));
 
-    let settled = false;
-    const settlePromise = Promise.allSettled(Array.from(DreamingService.activeBackgroundTasks)).then(() => { settled = true; });
-    const timeoutPromise = new Promise(resolve => setTimeout(resolve, timeoutMs));
+      await Promise.race([settlePromise, timeoutPromise]);
 
-    await Promise.race([settlePromise, timeoutPromise]);
+      if (!settled) {
+        break; // Timeout triggered
+      }
+      // If we finished successfully but new tasks were added, the while loop will re-check
+    }
 
-    // Re-check size in case tasks resolved/added right as timeout triggered
-    if (!settled && DreamingService.activeBackgroundTasks.size > 0) {
+    if (DreamingService.activeBackgroundTasks.size > 0) {
       logger.warn(`${DreamingService.activeBackgroundTasks.size} background database writes were dropped during graceful shutdown due to timeout.`);
     }
   }

--- a/src/services/dreamingService.ts
+++ b/src/services/dreamingService.ts
@@ -71,7 +71,7 @@ export interface DreamMemory {
  */
 export class DreamingService {
   /** Track pending fire-and-forget database writes for graceful shutdown */
-  static activeBackgroundTasks = new Set<Promise<any>>();
+  static activeBackgroundTasks = new Set<Promise<unknown>>();
 
 
   /** Cache of detected columns so we only check once per process lifetime */
@@ -414,15 +414,17 @@ export class DreamingService {
           if (ids.length > 0) {
             const baseBind = { tenantId };
             const updateBinds = ids.map(id => ({ id, ...baseBind }));
-            const updateTask = db.executeMany(
+            const updatePromise = db.executeMany(
               `UPDATE ai_dreaming_memory SET access_count = access_count + 1, last_accessed_at = CURRENT_TIMESTAMP WHERE id = :id AND tenant_id = :tenantId`,
               updateBinds
-            ).catch(bumpErr => {
+            );
+            const updateTask = updatePromise.catch(bumpErr => {
               logger.warn('[Dreaming] Failed to bump access_count:', bumpErr instanceof Error ? bumpErr.message : String(bumpErr));
-            }).finally(() => {
-              DreamingService.activeBackgroundTasks.delete(updateTask);
             });
             DreamingService.activeBackgroundTasks.add(updateTask);
+            updateTask.finally(() => {
+              DreamingService.activeBackgroundTasks.delete(updateTask);
+            });
           }
         }
 

--- a/src/services/dreamingService.ts
+++ b/src/services/dreamingService.ts
@@ -71,7 +71,27 @@ export interface DreamMemory {
  */
 export class DreamingService {
   /** Track pending fire-and-forget database writes for graceful shutdown */
-  static activeBackgroundTasks = new Set<Promise<unknown>>();
+  static readonly activeBackgroundTasks = new Set<Promise<unknown>>();
+
+  /**
+   * Waits for pending background tasks to settle, up to a specified timeout.
+   * Logs a warning if any tasks are still pending after the timeout.
+   */
+  static async waitForBackgroundTasks(timeoutMs: number = 5000): Promise<void> {
+    if (DreamingService.activeBackgroundTasks.size === 0) return;
+
+    logger.info(`Waiting for ${DreamingService.activeBackgroundTasks.size} pending database writes to complete...`);
+
+    let settled = false;
+    const settlePromise = Promise.allSettled(Array.from(DreamingService.activeBackgroundTasks)).then(() => { settled = true; });
+    const timeoutPromise = new Promise(resolve => setTimeout(resolve, timeoutMs));
+
+    await Promise.race([settlePromise, timeoutPromise]);
+
+    if (!settled && DreamingService.activeBackgroundTasks.size > 0) {
+      logger.warn(`${DreamingService.activeBackgroundTasks.size} background database writes were dropped during graceful shutdown due to timeout.`);
+    }
+  }
 
 
   /** Cache of detected columns so we only check once per process lifetime */
@@ -414,10 +434,16 @@ export class DreamingService {
           if (ids.length > 0) {
             const baseBind = { tenantId };
             const updateBinds = ids.map(id => ({ id, ...baseBind }));
-            const updatePromise = db.executeMany(
-              `UPDATE ai_dreaming_memory SET access_count = access_count + 1, last_accessed_at = CURRENT_TIMESTAMP WHERE id = :id AND tenant_id = :tenantId`,
-              updateBinds
-            );
+            let updatePromise: Promise<any>;
+            try {
+              updatePromise = db.executeMany(
+                `UPDATE ai_dreaming_memory SET access_count = access_count + 1, last_accessed_at = CURRENT_TIMESTAMP WHERE id = :id AND tenant_id = :tenantId`,
+                updateBinds
+              );
+            } catch (syncErr) {
+              // Catch synchronous throws from db drivers before they return a Promise
+              updatePromise = Promise.reject(syncErr);
+            }
             const updateTask = updatePromise.catch(bumpErr => {
               logger.warn('[Dreaming] Failed to bump access_count:', bumpErr instanceof Error ? bumpErr.message : String(bumpErr));
             });

--- a/src/services/dreamingService.ts
+++ b/src/services/dreamingService.ts
@@ -70,6 +70,8 @@ export interface DreamMemory {
  * as "dreams" that guide future suggestions.
  */
 export class DreamingService {
+  /** Track pending fire-and-forget database writes for graceful shutdown */
+  static activeBackgroundTasks = new Set<Promise<any>>();
 
 
   /** Cache of detected columns so we only check once per process lifetime */
@@ -411,13 +413,16 @@ export class DreamingService {
           const ids = rows.map(r => r['id'] as string).filter(Boolean);
           if (ids.length > 0) {
             const baseBind = { tenantId };
-            const binds = ids.map(id => ({ id, ...baseBind }));
-            db.executeMany(
+            const updateBinds = ids.map(id => ({ id, ...baseBind }));
+            const updateTask = db.executeMany(
               `UPDATE ai_dreaming_memory SET access_count = access_count + 1, last_accessed_at = CURRENT_TIMESTAMP WHERE id = :id AND tenant_id = :tenantId`,
-              binds
+              updateBinds
             ).catch(bumpErr => {
               logger.warn('[Dreaming] Failed to bump access_count:', bumpErr instanceof Error ? bumpErr.message : String(bumpErr));
+            }).finally(() => {
+              DreamingService.activeBackgroundTasks.delete(updateTask);
             });
+            DreamingService.activeBackgroundTasks.add(updateTask);
           }
         }
 

--- a/src/services/dreamingService.ts
+++ b/src/services/dreamingService.ts
@@ -78,14 +78,24 @@ export class DreamingService {
    * Logs a warning if any tasks are still pending after the timeout.
    */
   static async waitForBackgroundTasks(timeoutMs: number = 5000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+
     while (DreamingService.activeBackgroundTasks.size > 0) {
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) break; // Timeout triggered
+
       logger.info(`Waiting for ${DreamingService.activeBackgroundTasks.size} pending database writes to complete...`);
 
       let settled = false;
       const settlePromise = Promise.allSettled(Array.from(DreamingService.activeBackgroundTasks)).then(() => { settled = true; });
-      const timeoutPromise = new Promise(resolve => setTimeout(resolve, timeoutMs));
+
+      let timeoutId: NodeJS.Timeout;
+      const timeoutPromise = new Promise(resolve => {
+        timeoutId = setTimeout(resolve, remainingMs);
+      });
 
       await Promise.race([settlePromise, timeoutPromise]);
+      clearTimeout(timeoutId!); // Ensure event loop isn't held open if settle wins
 
       if (!settled) {
         break; // Timeout triggered
@@ -439,11 +449,9 @@ export class DreamingService {
           if (ids.length > 0) {
             const baseBind = { tenantId };
             const updateBinds = ids.map(id => ({ id, ...baseBind }));
-            const updatePromise = Promise.resolve().then(() =>
-              db.executeMany(
-                `UPDATE ai_dreaming_memory SET access_count = access_count + 1, last_accessed_at = CURRENT_TIMESTAMP WHERE id = :id AND tenant_id = :tenantId`,
-                updateBinds
-              )
+            const updatePromise = db.executeMany(
+              `UPDATE ai_dreaming_memory SET access_count = access_count + 1, last_accessed_at = CURRENT_TIMESTAMP WHERE id = :id AND tenant_id = :tenantId`,
+              updateBinds
             );
             const updateTask = updatePromise.catch(bumpErr => {
               logger.warn('[Dreaming] Failed to bump access_count:', bumpErr instanceof Error ? bumpErr.message : String(bumpErr));

--- a/src/services/dreamingService.ts
+++ b/src/services/dreamingService.ts
@@ -405,20 +405,19 @@ export class DreamingService {
 
         const rows = await db.query<Record<string, unknown>>(sql, binds);
 
-        // Bump access_count non-critically
+        // ⚡ Bolt Optimization: Fire and forget DB update to prevent "Write on Read" N+1 blocking
+        // Bump access_count non-critically without blocking the query return path.
         if (rows.length > 0) {
-          try {
-            const ids = rows.map(r => r['id'] as string).filter(Boolean);
-            if (ids.length > 0) {
-              const baseBind = { tenantId };
-              const binds = ids.map(id => ({ id, ...baseBind }));
-              await db.executeMany(
-                `UPDATE ai_dreaming_memory SET access_count = access_count + 1, last_accessed_at = CURRENT_TIMESTAMP WHERE id = :id AND tenant_id = :tenantId`,
-                binds
-              );
-            }
-          } catch (bumpErr) {
-            logger.warn('[Dreaming] Failed to bump access_count:', bumpErr instanceof Error ? bumpErr.message : String(bumpErr));
+          const ids = rows.map(r => r['id'] as string).filter(Boolean);
+          if (ids.length > 0) {
+            const baseBind = { tenantId };
+            const binds = ids.map(id => ({ id, ...baseBind }));
+            db.executeMany(
+              `UPDATE ai_dreaming_memory SET access_count = access_count + 1, last_accessed_at = CURRENT_TIMESTAMP WHERE id = :id AND tenant_id = :tenantId`,
+              binds
+            ).catch(bumpErr => {
+              logger.warn('[Dreaming] Failed to bump access_count:', bumpErr instanceof Error ? bumpErr.message : String(bumpErr));
+            });
           }
         }
 

--- a/src/services/dreamingService.ts
+++ b/src/services/dreamingService.ts
@@ -88,6 +88,7 @@ export class DreamingService {
 
     await Promise.race([settlePromise, timeoutPromise]);
 
+    // Re-check size in case tasks resolved/added right as timeout triggered
     if (!settled && DreamingService.activeBackgroundTasks.size > 0) {
       logger.warn(`${DreamingService.activeBackgroundTasks.size} background database writes were dropped during graceful shutdown due to timeout.`);
     }
@@ -434,16 +435,12 @@ export class DreamingService {
           if (ids.length > 0) {
             const baseBind = { tenantId };
             const updateBinds = ids.map(id => ({ id, ...baseBind }));
-            let updatePromise: Promise<any>;
-            try {
-              updatePromise = db.executeMany(
+            const updatePromise = Promise.resolve().then(() =>
+              db.executeMany(
                 `UPDATE ai_dreaming_memory SET access_count = access_count + 1, last_accessed_at = CURRENT_TIMESTAMP WHERE id = :id AND tenant_id = :tenantId`,
                 updateBinds
-              );
-            } catch (syncErr) {
-              // Catch synchronous throws from db drivers before they return a Promise
-              updatePromise = Promise.reject(syncErr);
-            }
+              )
+            );
             const updateTask = updatePromise.catch(bumpErr => {
               logger.warn('[Dreaming] Failed to bump access_count:', bumpErr instanceof Error ? bumpErr.message : String(bumpErr));
             });

--- a/tests/unit/dreaming-service.test.ts
+++ b/tests/unit/dreaming-service.test.ts
@@ -625,6 +625,9 @@ describe('DreamingService', () => {
 
       const rows = await DreamingService.queryDreamMemories('test-project', 'bump fails', 10);
 
+      // Wait for background tasks to settle to ensure warning is logged
+      await DreamingService.waitForBackgroundTasks(1000);
+
       assert.strictEqual(rows.length, 2, 'results must still be returned');
       assert.ok(
         mockLogger.warn.mock.calls.length >= 1,


### PR DESCRIPTION
💡 What: Refactored `access_count` bumping in `dreamingService.ts` to be a non-blocking "fire-and-forget" asynchronous operation.
🎯 Why: Previously, reading dreaming memories with vector search or large offsets resulted in the function waiting on an `UPDATE` statement before it could return data to the user. This "Write on Read" operation bottlenecked response times unnecessarily.
📊 Impact: Expected to reduce read latency by avoiding the N+1 `executeMany` await overhead on every read.
🔬 Measurement: Verified with existing tests to ensure correctness is preserved. Response times for `queryDreamMemories` with `vectorScores` should be measurably lower under high concurrency.

---
*PR created automatically by Jules for task [6715238038392455652](https://jules.google.com/task/6715238038392455652) started by @giauphan*